### PR TITLE
feat: generate rich metadata in index.json

### DIFF
--- a/src/clarity.py
+++ b/src/clarity.py
@@ -53,6 +53,7 @@ class ClarityAPI(object):
             body['allDatasources'] = True
             body['outputFrequency'] = 'hour'
             body['replyWithContinuationToken'] = CLARITY_USE_CONTINUATION_TOKEN
+            body['metricSelect'] = 'only *nowcast*'
             # body['format'] = 'csv-wide'
 
         redacted = json.loads(json.dumps(body))

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,4 @@
 import argparse
-import json
 import sys
 from decimal import Decimal
 
@@ -9,13 +8,18 @@ from config import CONTINUATION_TOKEN_OUTPUT_PATH, QUERY_OUTPUT_PATH
 from config import RAW_DATA_OUTPUT_PATH, CLEANED_DATA_OUTPUT_PATH
 from config import S3_BUCKET_NAME, S3_UPLOAD_PATH, INDEX_OUTPUT_PATH
 
-from utils import write_txt, write_json_dict, write_csv, run_postprocessing, read_json_dict
+from utils import write_txt, write_json_dict, write_csv, run_postprocessing
 
 from clarity import ClarityAPI
 from s3 import S3API
 
 
 def main(args):
+    if args.index:
+        s3api = S3API()
+        s3api.generate_index_file()
+        sys.exit(0)
+
     if not args.fetch and not args.push:
         log.error('You must specify either -f (--fetch) or -p (--push)')
         sys.exit(200)
@@ -60,12 +64,7 @@ def main(args):
     # Push select files from the output folder to the proper destinations in S3
     if args.push:
         s3api = S3API()
-
-        # Grab top-level objects (folder, etc) from S3
-        # Also, append the folder that we are currently uploading :)
-        tlos = s3api.list_folders() + [f'{S3_BUCKET_NAME}/{S3_UPLOAD_PATH}']
-        with open(INDEX_OUTPUT_PATH, 'w') as f:
-            json.dump(tlos, f)
+        s3api.generate_index_file()
 
         # Mapping of local file source path -> destination path within S3
         outfile_mapping: dict[str, list[str]] = {
@@ -104,5 +103,7 @@ if __name__ == '__main__':
     #parser.add_argument('-l', '--locations',  action='store_false' if OUTPUT_LOCATIONS_AS_JSON else 'store_true', help='Also output locations from Clarity REST API v2')
     # Data cleanup will take place in between these two independent steps
     parser.add_argument('-p', '--push',  action='store_true',  help='Upload resulting output data to S3 (Minio or AWS S3)')
+    parser.add_argument('-i', '--index', action='store_true',
+                        help="Only generate index.json file. don't fetch or push")
 
     main(args=parser.parse_args())

--- a/src/s3.py
+++ b/src/s3.py
@@ -1,6 +1,11 @@
-from config import log, IS_MINIO, S3_ENDPOINT_URL, S3_ACCESS_KEY, S3_SECRET_KEY
-from config import S3_REGION, S3_STORAGE_CLASS, S3_BUCKET_NAME
+import json
+import os
 import sys
+from datetime import datetime
+
+from config import log, IS_MINIO, S3_ENDPOINT_URL, S3_ACCESS_KEY, S3_SECRET_KEY, LOCAL_OUTPUT_DIR
+from config import INDEX_OUTPUT_PATH, S3_UPLOAD_PATH, CLEANED_DATA_OUTPUT_PATH
+from config import S3_REGION, S3_STORAGE_CLASS, S3_BUCKET_NAME
 
 import s3fs
 
@@ -24,6 +29,52 @@ s3_client = s3fs.S3FileSystem(anon=False, key=S3_ACCESS_KEY, secret=S3_SECRET_KE
 class S3API(object):
     def list_folders(self):
         return s3_client.ls(path=f'{S3_BUCKET_NAME}/')
+
+    def read_file(self, path):
+        # WARNING: filename collisions would be bad here
+        if S3_UPLOAD_PATH in path:
+            # this is the currently-queued upload - file only exists locally
+            with open(CLEANED_DATA_OUTPUT_PATH, 'r') as f:
+                json_contents = json.load(f)
+                return json_contents, os.stat(CLEANED_DATA_OUTPUT_PATH).st_size
+        else:
+            # file does not exist locally - read from S3 bucket
+            with s3_client.open(path, 'r') as f:
+                json_contents = json.load(f)
+                return json_contents, s3_client.stat(path)['size']
+
+    def find_earliest_latest_timestamps(self, content):
+        # {"datasourceId":"DJHFB1439","time":"2025-10-23T20:00:00.000Z","metric":"no2Conc1HourMean","raw":-0.08,"value":7.73,"status":"calibrated-ready"},
+        timestamps = [datetime.fromisoformat(val['time']) for val in content]
+        return min(timestamps), max(timestamps)
+
+    def generate_index_file(self):
+        # Grab top-level objects (folder, etc) from S3
+        # Also, append the folder that we are currently uploading :)
+        tlos = self.list_folders() + [f'{S3_BUCKET_NAME}/{S3_UPLOAD_PATH}']
+
+        metadata = []
+        for tlo in tlos:
+            if 'index.json' in tlo or 'token.txt' in tlo or 'locations.json' in tlo:
+                print (f'Skipping {tlo}...')
+                continue
+            print (f'Analyzing {tlo}...')
+            content, size = self.read_file(tlo)
+            redacted = f'{json.loads(json.dumps(content))[:40]}...'
+            print(f'content = {redacted}')
+            print(f'size = {size}')
+            earliest, latest = self.find_earliest_latest_timestamps(content=content)
+            print(f'earliest = {earliest}')
+            print(f'latest = {latest}')
+            metadata.append({
+                'path': tlo,
+                'size': size,
+                'startTime': earliest.isoformat(),
+                'endTime': latest.isoformat(),
+            })
+
+        with open(INDEX_OUTPUT_PATH, 'w') as f:
+            json.dump(metadata, f)
 
     def push_to_s3(self, local_path: str, remote_path: str):
         # Determine destination within S3

--- a/src/s3.py
+++ b/src/s3.py
@@ -53,6 +53,7 @@ class S3API(object):
         # Also, append the folder that we are currently uploading :)
         tlos = self.list_folders() + [f'{S3_BUCKET_NAME}/{S3_UPLOAD_PATH}']
 
+        print(f'Generating {INDEX_OUTPUT_PATH}...')
         metadata = []
         for tlo in tlos:
             if 'index.json' in tlo or 'token.txt' in tlo or 'locations.json' in tlo:
@@ -61,11 +62,11 @@ class S3API(object):
             print (f'Analyzing {tlo}...')
             content, size = self.read_file(tlo)
             redacted = f'{json.loads(json.dumps(content))[:40]}...'
-            print(f'content = {redacted}')
-            print(f'size = {size}')
+            #print(f'content = {redacted}')
+            #print(f'size = {size}')
             earliest, latest = self.find_earliest_latest_timestamps(content=content)
-            print(f'earliest = {earliest}')
-            print(f'latest = {latest}')
+            #print(f'earliest = {earliest}')
+            #print(f'latest = {latest}')
             metadata.append({
                 'path': tlo,
                 'size': size,


### PR DESCRIPTION
## Problem
`index.json` provides a list of filenames, but too many assumptions need to be made about this data to format and visualize reliably in the frontend

## Approach
* feat: generate richer metadata in `index.json`:
    * `path` == path to object in bucket
    * `size` == size of object within bucket (in bytes)
    * `startTime` == earliest timestamp contained in this file (ISO fomat)
    * `endTime` == latest timestamp contained in this file (ISO format)

## How to Test
1. Checkout and run this branch locally w/ MinIO support:
    * You should see that `index.json` has been uploaded as part of the process
```bash
docker compose --profile pipeline build && \
    docker compose --profile minio up -d && \
    docker compose run --remove-orphans -it clarityfetch && \
    docker compose run --remove-orphans -it s3push
```
2. After the pipeline runs, check the file in MinIO
    * You should see that `index.json` is housed in the bucket
    * You should see that `index.json` has been updated recently as part of the latest pipeline run
3. Download this file from MinIO and examine it
    * You should see that `index.json` has the following format:
```bash
% cat ~/Downloads/index.json | jq
[
  {
    "path": "chicago-aq/2025-10-21@17:17:15.json",
    "size": 18336171,
    "startTime": "2025-10-20T18:00:00+00:00",
    "endTime": "2025-10-21T16:00:00+00:00"
  },
  {
    "path": "chicago-aq/2025-10-21@19:12:09.json",
    "size": 1599329,
    "startTime": "2025-10-21T16:00:00+00:00",
    "endTime": "2025-10-21T18:00:00+00:00"
  },
  {
    "path": "chicago-aq/latest.json",
    "size": 1599329,
    "startTime": "2025-10-21T16:00:00+00:00",
    "endTime": "2025-10-21T18:00:00+00:00"
  },
  {
    "path": "chicago-aq/2025-10-29@21:23:22",
    "size": 3843283,
    "startTime": "2025-10-28T22:00:00+00:00",
    "endTime": "2025-10-29T20:00:00+00:00"
  }
]
```