### PR TITLE
fix: collect latest metrics in latest.geojson

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+# Starting MinIO container
+echo "Ensuring MinIO container is running..."
+docker compose --profile minio up -d --remove-orphans
+
 # Clear out stale data from previous runs before running again
 # TODO: make this an option?
 echo -n "Clearing previous run data."

--- a/src/s3.py
+++ b/src/s3.py
@@ -49,19 +49,27 @@ class S3API(object):
                 json_contents = json.load(f)
                 return json_contents, s3_client.stat(path)['size']
 
+    # Given a list of ISO/UTC timestamps, return earliest/latest dates
+    def find_earliest_latest_timestamps_from_list(self, timestamps):
+        # ["2025-10-23T20:00:00.000Z","2025-10-23T21:00:00.000Z","2025-10-23T22:00:00.000Z"]
+        timestamps = [datetime.fromisoformat(t) for t in timestamps]
+        return min(timestamps), max(timestamps)
+
+    # Given a data response from Clarity (array of metrics a la CSV), return earliest/latest dates
     def find_earliest_latest_timestamps(self, content):
         # {"datasourceId":"DJHFB1439","time":"2025-10-23T20:00:00.000Z","metric":"no2Conc1HourMean","raw":-0.08,"value":7.73,"status":"calibrated-ready"},
-        timestamps = [datetime.fromisoformat(feature['time']) for feature in content]
-        return min(timestamps), max(timestamps)
+        timestamps = [f['time'] for f in content]
+        return self.find_earliest_latest_timestamps_from_list(timestamps)
 
+    # Given our "simple" GeoJSON format, return earliest/latest dates
     def find_earliest_latest_timestamps_geojson_simple(self, content):
-        timestamps = [datetime.fromisoformat(feature['properties']['time']) for feature in content['features']]
-        return min(timestamps), max(timestamps)
+        timestamps = [f['properties']['time'] for f in content['features']]
+        return self.find_earliest_latest_timestamps_from_list(timestamps)
 
+    # Given our "historical" GeoJSON format, return earliest/latest dates
     def find_earliest_latest_timestamps_geojson_historical(self, content):
-        str_timestamps = content['features'][0]['properties']['pm2_5ConcMassNowcast'].keys()
-        timestamps = [datetime.fromisoformat(timestamp) for timestamp in str_timestamps]
-        return min(timestamps), max(timestamps)
+        timestamps = content['features'][0]['properties']['pm2_5ConcMassNowcast'].keys()
+        return self.find_earliest_latest_timestamps_from_list(timestamps)
 
     def generate_index_file(self):
         # Grab top-level objects (folder, etc) from S3

--- a/src/utils.py
+++ b/src/utils.py
@@ -87,6 +87,7 @@ def to_geojson(locations, properties, fetch_time):
 def to_geojson_simple(data, locations, fetch_time):
     # Read all metrics from each datasource into a map of properties
     properties = {}
+
     for d in data:
         # The datasourceId for this sensor in Clarity's system
         datasourceId = d["datasourceId"]
@@ -112,8 +113,8 @@ def to_geojson_simple(data, locations, fetch_time):
             }
 
         # Assumption: data will always be ordered newest -> oldest
-        if datasource_properties[metric_name] is None:
-            # Overwrite particular metric from this line if we haven't seen a value
+        if datasource_properties[metric_name] is None and collection_time > datasource_properties['time']:
+            # Overwrite particular metric from this line if we haven't seen a value, or if this value is later
             # No need to preserve/store "raw" or "status"
             datasource_properties['time'] = collection_time
             datasource_properties[metric_name] = metric_value


### PR DESCRIPTION
## Problem
In our `latest.geojson`, we sometimes see older or conflicting values for `time`


## Approach
* fix: don't assume that returned metric data is sorted by time (it won't be)
* refactor: rework earliest/latest functions to share base logic
* fix: run minio automatically as part of local `./run.sh`


## How to Test
1. Checkout and run this branch locally: `git fetch --all && git checkout lambert8/bugfix/fix-latest-timestamp-in-simple-geojson`
2. Use the helper script to run the pipeline locally: `./run.sh`
   * You should see a MinIO container/service start up
   * You should see the `clarity-aq-pipeline` container image is built
   * You should see the `clarityfetch` stage is run first, and should output files locally to `./data`
   * You should see the `s3push` stage is run last, which will push desired output files from `./data` into MinIO
3. After running the pipeline, check you local files to ensure that the values for `time` now reflect more recent values: `cat data/latest.geojson | grep "time" | sort -u` (replace the string literal here with your actual latest `time`)
    * You should see that all values for `time` now somewhat match
        * note that `timestamp` will always be different, but `time` should be the same one or two values
        * if a nowcast value has been generated for the next hour, you'll see the next value here (e.g. `"time": "2025-11-11T17:00:00.000Z"`)
        * if any sensors have not yet generated their nowcast, you'll see the previous value here (e.g. `"time": "2025-11-11T16:00:00.000Z"`)
        * for example:
```bash
% cat data/latest.geojson | grep "time" | sort -ur
    "timestamp": "2025-11-11T20:07:54Z",              # when the script ran: 20:00 => 8 PM UTC => 2 PM central
                "time": "2025-11-11T19:00:00.000Z",   # nowcast value for this hour: 19:00 => 7 PM UTC => 1 PM central
                "time": "2025-11-11T18:00:00.000Z",   # nowcast value for previous hour: 18:00 => 6 PM UTC => 12 PM central
```
4. Verify that the same is true for `historical.geojson` - all sensors should share the same 22-24 timestamps
    * You should see that the one or two dates at the top of this list match what we saw in `latest.geojson`
```bash
% cat data/historical.geojson | grep "000Z" | awk '{print $1}' | sort -ur         
"2025-11-11T19:00:00.000Z":
"2025-11-11T18:00:00.000Z":
"2025-11-11T17:00:00.000Z":
"2025-11-11T16:00:00.000Z":
"2025-11-11T15:00:00.000Z":
"2025-11-11T14:00:00.000Z":
"2025-11-11T13:00:00.000Z":
"2025-11-11T12:00:00.000Z":
"2025-11-11T11:00:00.000Z":
"2025-11-11T10:00:00.000Z":
"2025-11-11T09:00:00.000Z":
"2025-11-11T08:00:00.000Z":
"2025-11-11T07:00:00.000Z":
"2025-11-11T06:00:00.000Z":
"2025-11-11T05:00:00.000Z":
"2025-11-11T04:00:00.000Z":
"2025-11-11T03:00:00.000Z":
"2025-11-11T02:00:00.000Z":
"2025-11-11T01:00:00.000Z":
"2025-11-11T00:00:00.000Z":
"2025-11-10T23:00:00.000Z":
"2025-11-10T22:00:00.000Z":
"2025-11-10T21:00:00.000Z":
```
