### PR TITLE
fix: fixed seasonal average calculation, simplify to range of months

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -234,15 +234,12 @@ def main(args):
         })
         seasonal['type'] = 'season'
 
-        # Ensure date in the correct format - 2025-S03, 2025-S02, etc
-        seasonal['date'] = seasonal['date'].map(lambda d: d.split('-')[0]+'-'+d.split('-')[1][1:].zfill(2))
-
         # Ensure column consistency: n_valid, type, date, is_valid, mean_pm2
         log.info(f'Compiling yearly sensor data...')
         yearly = pd.read_csv('data/summary-yearly.csv').rename(columns={
             'n_valid_days': 'n_valid',
             'is_valid_season': 'is_valid',
-            'season': 'date',
+            'year': 'date',
             'yearly_mean_pm25': 'mean_pm25',
             # .. define new metrics here, use consistent column names for hourly + daily ... #
         })

--- a/src/main.py
+++ b/src/main.py
@@ -50,7 +50,7 @@ def main(args):
 
         log.info(f'Result of merge:')
         merged_df = s3api.update_locations_df(new_locations_df)
-        print(merged_df[['datasourceId','name','community','zip']][merged_df['community'] == 'ASHBURN'])
+        print(merged_df[['datasourceId','name','community','zip','ward']][merged_df['community'] == 'ASHBURN'])
 
         sys.exit(0)
 

--- a/src/main.py
+++ b/src/main.py
@@ -268,7 +268,7 @@ if __name__ == '__main__':
     #     Historical Measurements => startTime to endTime
     #     Recent Measurements => startTime to now
     parser.add_argument('-H', '--historical', action='store_true',
-                        help="Request a report of historical measurements between startTime and endTime (may take awhile). Defaults to previous month.")
+                        help="Request a report of historical measurements between startTime and endTime (may take awhile). Defaults to previous month. WARNING: Historical Measurement requests are expensive for the Clarity API, and are limited to ~30 requests every ~24 hours.")
     parser.add_argument('-r', '--recent', action='store_true',
                         help="Compute recent measurements data between startTime and now. Defaults to 1 hour prior to time of request.")
 
@@ -284,7 +284,7 @@ if __name__ == '__main__':
 
     # Actions to perform on the given set of measurements
     parser.add_argument('-f', '--fetch', action='store_true',
-                        help="Fetch new measurement values from Clarity REAST API V2 (may take awhile)")
+                        help="Fetch new measurement values from Clarity REST API V2 (may take awhile)")
     parser.add_argument('-c', '--clean', action='store_true',
                         help="Clean the measurement data by running the related R script, compute daily/hourly averages")
     parser.add_argument('-m', '--merge', action='store_true',

--- a/src/utils.py
+++ b/src/utils.py
@@ -77,7 +77,7 @@ def get_previous_week_dates():
 #   Used for --recent --monthly
 def get_current_month_dates():
     current_month_start = datetime.now(UTC).replace(day=1, hour=0, minute=0, second=0, microsecond=0)
-    current_month_end = current_month_start + timedelta(months=1)
+    current_month_end = current_month_start + relativedelta(months=1)
 
     return isoformat(current_month_start), isoformat(current_month_end)
 
@@ -93,27 +93,26 @@ def get_previous_month_dates():
 
 
 # For simplicity, "season" is currently defined as a set of months
-#   S1 => Spring => 3/21 ~ 6/21
-#   S2 => Summer => 6/21 ~ 9/23
-#   S3 => Fall => 9/23 ~ 12/21
-#   S4 => Winter => 12/21 ~ 3/21
+#   S1 => Spring => March / April / May
+#   S2 => Summer => June / July / August
+#   S3 => Fall => September / October / November
+#   S4 => Winter => December / January / February
 def get_seasonal_boundaries(date=datetime.now(UTC)):
     month_start = date.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
     month = month_start.month
     year = month_start.year
-    day_of_month = month_start.day
 
     return {
-        'S1': (datetime(year, 3, 21), datetime(year, 6, 21) - timedelta(microseconds=1)),
-        'S2': (datetime(year, 6, 21), datetime(year, 9, 23) - timedelta(microseconds=1)),
-        'S3': (datetime(year, 9, 23), datetime(year, 12, 21) - timedelta(microseconds=1)),
+        'spring': (datetime(year, 3, 0), datetime(year, 6, 0) - timedelta(microseconds=1)),
+        'summer': (datetime(year, 6, 0), datetime(year, 9, 0) - timedelta(microseconds=1)),
+        'autumn': (datetime(year, 9, 0), datetime(year, 12, 0) - timedelta(microseconds=1)),
 
         # Winter may use last year or next year
         #   month == 12 and day_of_month >= 21  =>  we are early in the winter, it will last until next year
         #   month != 12 =>  we are late in the winter, it has gone on since last year
-        'S4': (
-            datetime(year if month == 12 and day_of_month >= 21 else year - 1, 12, 21),
-            datetime(year + 1 if month == 12 and day_of_month >= 21 else year, 3, 21)  - timedelta(microseconds=1)
+        'winter': (
+            datetime(year if month == 12 else year - 1, 12, 0),
+            datetime(year + 1 if month == 12 else year, 3, 0) - timedelta(microseconds=1)
         ),
     }
 
@@ -140,7 +139,7 @@ def get_previous_season_dates():
     a_day_last_season = current_season_start - timedelta(days=2)
     previous_season = get_season(date=a_day_last_season)
 
-    return seasonal_bounds[previous_season]
+    return seasonal_bounds[previous_season], previous_season
 
 
 # Compute today's timestamp, use that to find first microsecond of the current season
@@ -149,7 +148,7 @@ def get_current_season_dates():
     bounds = get_seasonal_boundaries(date=current_month_start)
     current_season = get_season(date=current_month_start)
 
-    return bounds[current_season]
+    return bounds[current_season], current_season
 
 
 # Compute today's timestamp, use that to find first microsecond of the previous year

--- a/src/utils.py
+++ b/src/utils.py
@@ -103,16 +103,16 @@ def get_seasonal_boundaries(date=datetime.now(UTC)):
     year = month_start.year
 
     return {
-        'spring': (datetime(year, 3, 0), datetime(year, 6, 0) - timedelta(microseconds=1)),
-        'summer': (datetime(year, 6, 0), datetime(year, 9, 0) - timedelta(microseconds=1)),
-        'autumn': (datetime(year, 9, 0), datetime(year, 12, 0) - timedelta(microseconds=1)),
+        'spring': (datetime(year, 3, 1, tzinfo=UTC), datetime(year, 6, 1, tzinfo=UTC) - timedelta(microseconds=1)),
+        'summer': (datetime(year, 6, 1, tzinfo=UTC), datetime(year, 9, 1, tzinfo=UTC) - timedelta(microseconds=1)),
+        'autumn': (datetime(year, 9, 1, tzinfo=UTC), datetime(year, 12, 1, tzinfo=UTC) - timedelta(microseconds=1)),
 
         # Winter may use last year or next year
         #   month == 12 and day_of_month >= 21  =>  we are early in the winter, it will last until next year
         #   month != 12 =>  we are late in the winter, it has gone on since last year
         'winter': (
-            datetime(year if month == 12 else year - 1, 12, 0),
-            datetime(year + 1 if month == 12 else year, 3, 0) - timedelta(microseconds=1)
+            datetime(year if month == 12 else year - 1, 12, 1, tzinfo=UTC),
+            datetime(year + 1 if month == 12 else year, 3, 1, tzinfo=UTC) - timedelta(microseconds=1)
         ),
     }
 
@@ -138,17 +138,19 @@ def get_previous_season_dates():
     # Arbitrarily subtract 2 days (any number > 1 will do)
     a_day_last_season = current_season_start - timedelta(days=2)
     previous_season = get_season(date=a_day_last_season)
+    (previous_season_start, previous_season_end) = seasonal_bounds[previous_season]
 
-    return seasonal_bounds[previous_season]
+    return isoformat(previous_season_start), isoformat(previous_season_end)
 
 
 # Compute today's timestamp, use that to find first microsecond of the current season
 def get_current_season_dates():
     current_month_start = datetime.now(UTC).replace(day=1, hour=0, minute=0, second=0, microsecond=0)
-    bounds = get_seasonal_boundaries(date=current_month_start)
+    seasonal_bounds = get_seasonal_boundaries(date=current_month_start)
     current_season = get_season(date=current_month_start)
+    (current_season_start, current_season_end) = seasonal_bounds[current_season]
 
-    return bounds[current_season]
+    return isoformat(current_season_start), isoformat(current_season_end)
 
 
 # Compute today's timestamp, use that to find first microsecond of the previous year

--- a/src/utils.py
+++ b/src/utils.py
@@ -139,7 +139,7 @@ def get_previous_season_dates():
     a_day_last_season = current_season_start - timedelta(days=2)
     previous_season = get_season(date=a_day_last_season)
 
-    return seasonal_bounds[previous_season], previous_season
+    return seasonal_bounds[previous_season]
 
 
 # Compute today's timestamp, use that to find first microsecond of the current season
@@ -148,7 +148,7 @@ def get_current_season_dates():
     bounds = get_seasonal_boundaries(date=current_month_start)
     current_season = get_season(date=current_month_start)
 
-    return bounds[current_season], current_season
+    return bounds[current_season]
 
 
 # Compute today's timestamp, use that to find first microsecond of the previous year


### PR DESCRIPTION
## Problem
Seasonal averages are currently causing an error, and should be simplified to a month range anyways

Fixes #17 
Related to #20 

## Approach
* fix: simplify definition of "season" to meteorological :+1:
    * Spring => March ~ May => 03/01 - 06/01
    * Summer  => June ~ August => 06/01 - 09/01
    * Autumn  => September ~ November => 09/01 - 12/01
    * Winter  => December ~ February => 12/01 - 03/01
* chore: retested to make sure that running the seasonal calculation no longer encounters an error

## How to Test
### First-Time Setup
* Docker Desktop
    * need to provide the default more RAM / memory under Settings > Resources
    * otherwise, the terminal / docker daemon will freeze up and stop
        * @sanket1009 we witnessed this behavior during our meeting

1. Checkout and run this branch locally
2. Create `.env` (if you haven't already) by copying `.env.example` to `.env`
3. Edit the `.env` and add the following at the bottom of the file:
```env
# Get your API key from the Clarity Dashboard by signing in to https://dashboard.clarity.io
# At the top-right, click on the user icon to open the side panel where you can copy your API key
# Paste your API key here in the .env file
CLARITY_API_KEY=

# Run MinIO S3 instance for local testing, set admin username/password
S3_ENDPOINT_URL=http://localhost:9000
MINIO_ROOT_USER=minio
MINIO_ROOT_PASSWORD=minio
```
4. Start up MinIO: `docker compose up -d`
    * You should see the MinIO image downloads and starts
    * You should see another container run that will automatically create the `chicago-aq` bucket
    * You may see a third container run that will automatically enable public downloads for these bucket contents (but this is only run when the bucket is first created) 

### Sanity Check: Recent Measurements
1. You can quickly verify that the pipeline is setup correctly by fetching the most recent measurements from Clarity's ~24 hour cache: `docker compose run --build --rm -it aq --recent --fetch --clean --merge`
    * You should see this fetches the past 3 full hours of metrics + any metrics from the current hour - this is to prevent any previously-correct hourly readings from being overwritten by an incomplete or partial hourly reading 
    * You should see that Clarity returns CSV data for the metrics in the chosen period
    * You should see that the downloaded CSV data is then passed into the R script for cleaning
    * You should see that the R script aggregates the per-minute data points into hourly data
    * You should see the script then pivots this DataFrame on `datasourceId` to produce our desired format: where each row is a unique `type` + `date` combo and every other column is a unique `datasourceId`
    * You should see that any new row and/or column values are merged into our existing `mean_pm25.parquet` dataset from MinIO

### Computing Seasonal Averages via Historical Measurements
Warning: Historical Measurements requests to the Clarity API are expensive, and are limited to ~30 within a ~24 hour period. Please only use `--fetch` when absolutely needed, and remove this argument to reuse already-fetched data whenever possible :pray:

1. You can build & run all pipeline stages in one step: `docker compose run --build --rm -it aq --historical --fetch --clean --merge --seasonal`
    * You should see Docker begin building the image layer by layer, starting with installing OS + conda dependencies, then adding our own source code and default commands
    * You should see that once the image is built, it begins running by submitting a request to the Clarity API for Historical Measurements
    * You should see the script polls (waiting for the report to be "Ready") every 10 seconds for a maximum of 50 attempts  
    * You should see that after the report is Ready, a large S3 download link is provided to the CSV results contained in the report. The script may hang here for a bit while it downloads if the date range provided is overly large.
    * You should see that any locations that are contained in the CSV data are merged into our `locations.parquet` dataset (in S3 / MinIO)
    * You should see that the downloaded CSV data is then passed into the R script for cleaning
    * You should see that the R script aggregates the per-minute data points into hourly data
        * With enough hourly data, you should see that daily averages are produced from the hourly data
        * With enough daily data, you should see that weekly averages are produced from the daily data
        * With enough daily data, you should see that monthly averages are produced from the daily data
        * With enough daily data, you should see that seasonal averages are produced from the daily data
        * ~~With enough daily data, you should see that yearly averages are produced from the daily data~~ this is true, but there isn't enough data yet at this time to produce a yearly reading
    * You should see the script concatenates all valid rows from the hourly + daily + weekly + monthly + seasonal + yearly into a single DataFrame
    * You should see the script then pivots this large DataFrame on `datasourceId` to produce our desired format: where each row is a unique `type` + `date` combo and every other column is a unique `datasourceId`
    * You should see that any new row and/or column values are merged into our existing `mean_pm25.parquet` dataset from MinIO


Now to fulfill #20, we can run both of the following while pointing at our production S3 bucket:

Past season(s): Populate 2025-autumn and all monthly + weekly + daily + hourly averages within that period
```
docker compose run --build --rm -it aq --historical --fetch --clean --merge '2025-09-01T00:00:00Z' '2025-12-01T00:00:00Z'
```

Last season: Populate 2026-winter and all monthly + weekly + daily + hourly averages within that period
```
docker compose run --build --rm -it aq --historical --fetch --clean --merge --seasonal
```

Note that there will be no yearly average calculated for `2025`, as this year's data is incomplete

For example, resulting dataset will likely look something like this + some more hourly/daily rows:
```python
       type                 date  DACZY2913  DAETQ5676  DAEXF8484  ...  DZIHS7092  DZKWB0839  DZLAV7766  DZTFU6199  DZUWB2477
1    season          2026-winter  20.515009  26.959470  23.164020  ...  25.517428  28.738472  23.454293  24.958570  29.765116
0    season          2025-autumn  13.381726  17.049846  13.992150  ...  14.703303  17.040309  14.347551  15.320814  18.567236
7     month              2026-02  23.811983  28.838213  25.313676  ...  28.337121  31.601527  26.656285  27.096696  31.853206
6     month              2026-01  13.263748  18.977253  15.268047  ...  17.329981  20.467776  14.957234  17.036295  23.073780
5     month              2025-12  24.320535  32.729775  28.608949  ...  30.629834  34.156386  28.511033  30.438519  34.138737
..      ...                  ...        ...        ...        ...  ...        ...        ...        ...        ...        ...
219    hour  2025-09-01 04:00:00   5.360000  39.136667  24.310000  ...   9.455000   5.500000  18.010000  31.250000  15.392500
218    hour  2025-09-01 03:00:00   5.277500  34.487500  25.013333  ...   9.176667   7.463333  22.980000  34.050000  15.186667
217    hour  2025-09-01 02:00:00   6.870000  27.910000  17.097500  ...   9.760000   9.587500  30.310000  22.490000  15.990000
216    hour  2025-09-01 01:00:00   9.932500  15.837500  11.793333  ...   8.270000  10.293333   9.936667  24.143333  11.396667
215    hour           2025-09-01  10.050000   9.283333   7.317500  ...   5.716667   8.635000   6.240000   9.912500   7.767500
```
