### PR TITLE
feat: index/sort optimization, operations.yml and definitions for nowcast_aqi + mean_pm25

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -52,5 +52,5 @@ jobs:
 
       # Fetch Clarity API data and save raw files locally
       - name: Fetch Clarity sensor data, clean CSV data, merge into Parquet dataset
-        run: docker compose run --remove-orphans -e CLARITY_API_KEY=${{ secrets.CLARITY_API_TOKEN }} -e S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }} -e S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }} aq --historical --fetch --merge --clean --daily
+        run: docker compose run --remove-orphans -e CLARITY_API_KEY=${{ secrets.CLARITY_API_TOKEN }} -e S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }} -e S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }} aq --historical --daily --op nowcast_aqi mean_pm25
 

--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -52,4 +52,4 @@ jobs:
 
       # Fetch Clarity API data and save raw files locally
       - name: Fetch Clarity sensor data, clean CSV data, merge into Parquet dataset
-        run: docker compose run --remove-orphans -e CLARITY_API_KEY=${{ secrets.CLARITY_API_TOKEN }} -e S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }} -e S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }} aq --historical --fetch --merge --clean --monthly
+        run: docker compose run --remove-orphans -e CLARITY_API_KEY=${{ secrets.CLARITY_API_TOKEN }} -e S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }} -e S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }} aq --historical --monthly --op nowcast_aqi mean_pm25

--- a/.github/workflows/recent.yml
+++ b/.github/workflows/recent.yml
@@ -57,5 +57,5 @@ jobs:
 
       # Fetch Clarity API data and save raw files locally
       - name: Fetch Clarity sensor data, clean CSV data, merge into Parquet dataset
-        run: docker compose run --remove-orphans -e CLARITY_API_KEY=${{ secrets.CLARITY_API_TOKEN }} -e S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }} -e S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }} aq --recent --fetch --merge --clean
+        run: docker compose run --remove-orphans -e CLARITY_API_KEY=${{ secrets.CLARITY_API_TOKEN }} -e S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }} -e S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }} aq --recent --op nowcast_aqi mean_pm25
 

--- a/.github/workflows/seasonal.yml
+++ b/.github/workflows/seasonal.yml
@@ -61,4 +61,4 @@ jobs:
 
       # Fetch Clarity API data and save raw files locally
       - name: Fetch Clarity sensor data, clean CSV data, merge into Parquet dataset
-        run: docker compose run --remove-orphans -e CLARITY_API_KEY=${{ secrets.CLARITY_API_TOKEN }} -e S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }} -e S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }} aq --historical --fetch --merge --clean --seasonal
+        run: docker compose run --remove-orphans -e CLARITY_API_KEY=${{ secrets.CLARITY_API_TOKEN }} -e S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }} -e S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }} aq --historical --seasonal --op nowcast_aqi mean_pm25

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -52,4 +52,4 @@ jobs:
 
       # Fetch Clarity API data and save raw files locally
       - name: Fetch Clarity sensor data, clean CSV data, merge into Parquet dataset
-        run: docker compose run --remove-orphans -e CLARITY_API_KEY=${{ secrets.CLARITY_API_TOKEN }} -e S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }} -e S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }} aq --historical --fetch --merge --clean --weekly
+        run: docker compose run --remove-orphans -e CLARITY_API_KEY=${{ secrets.CLARITY_API_TOKEN }} -e S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }} -e S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }} aq --historical --weekly --op nowcast_aqi mean_pm25

--- a/.github/workflows/yearly.yml
+++ b/.github/workflows/yearly.yml
@@ -52,4 +52,4 @@ jobs:
 
       # Fetch Clarity API data and save raw files locally
       - name: Fetch Clarity sensor data, clean CSV data, merge into Parquet dataset
-        run: docker compose run --remove-orphans -e CLARITY_API_KEY=${{ secrets.CLARITY_API_TOKEN }} -e S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }} -e S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }} aq --historical --fetch --merge --clean --yearly
+        run: docker compose run --remove-orphans -e CLARITY_API_KEY=${{ secrets.CLARITY_API_TOKEN }} -e S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }} -e S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }} aq --historical --yearly --op nowcast_aqi mean_pm25

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ RUN micromamba install -n base -f environment.yml -y && \
 
 # Include our Python and R source
 COPY src ./src
-COPY clarity_qa_qc.R ./clarity_qa_qc.R
+COPY scripts ./scripts
+COPY operations.yml ./operations.yml
 
 # Mount in data volume at runtime
 VOLUME /home/rstudio/data

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # clarity-aq-pipeline
 
-This repo holds scripts and Github Actions that extract and manipulate air quality sensor data from Clarity's API for aggregated storage and display in TDB web-based visualizations.
+This repo holds scripts and GitHub Actions that extract and manipulate air quality sensor data from Clarity's API for aggregated storage and display in TDB web-based visualizations.
 
 ## Resources
 
@@ -71,25 +71,25 @@ If you modify any of the source code, you will need to rebuild the image (or add
 Each of these examples will run all stages of the pipeline (see below). We provide:
 ```bash
 # Recent measurements (default: past ~3 hours)
-docker compose run --rm -it aq --recent --fetch --clean --merge
+docker compose run --rm -it aq --recent --op nowcast_aqi mean_pm25
 # Historical measurements (default: past full month)
-docker compose run --rm -it aq --historical --fetch --clean --merge
+docker compose run --rm -it aq --historical  --op nowcast_aqi mean_pm25
 
 # Past full day (>20 valid hours)
-docker compose run --rm -it aq --historical --fetch --clean --merge --daily
+docker compose run --rm -it aq --historical --daily --op nowcast_aqi mean_pm25
 # Past full week (>5 valid days)
-docker compose run --rm -it aq --historical --fetch --clean --merge --weekly
+docker compose run --rm -it aq --historical --weekly --op nowcast_aqi mean_pm25
 # Past full month (>21 valid days)
-docker compose run --rm -it aq --historical --fetch --clean --merge --monthly
+docker compose run --rm -it aq --historical --monthly --op nowcast_aqi mean_pm25
 # Past full season (>60 valid days)
-docker compose run --rm -it aq --historical --fetch --clean --merge --seasonal
+docker compose run --rm -it aq --historical --seasonal --op nowcast_aqi mean_pm25
 # Past full year (>220 valid days)
-docker compose run --rm -it aq --historical --fetch --clean --merge --yearly
+docker compose run --rm -it aq --historical --yearly --op nowcast_aqi mean_pm25
 
 # Custom date range: between 2026-01-01T00:00:00Z and now
-docker compose run --rm -it aq --recent --fetch --clean --merge '2026-01-01T00:00:00Z'
+docker compose run --rm -it aq --recent '2026-01-01T00:00:00Z' --op nowcast_aqi mean_pm25
 # Custom date range: between 2026-01-01T00:00:00Z and 2026-02-01T00:00:00Z
-docker compose run --rm -it aq --historical --fetch --clean --merge '2026-01-01T00:00:00Z' '2026-02-01T00:00:00Z'
+docker compose run --rm -it aq --historical '2026-01-01T00:00:00Z' '2026-02-01T00:00:00Z' --op nowcast_aqi mean_pm25
 ```
 
 ### Conda + Python (Local Development)
@@ -99,25 +99,25 @@ conda create -n clarity -f environment.yml
 conda activate clarity
 
 # Recent measurements (default: past ~3 hours)
-python ./main.py --recent --fetch --clean --merge
+python ./main.py --recent --op nowcast_aqi mean_pm25
 # Historical measurements (default: past full month)
-python ./main.py --historical --fetch --clean --merge
+python ./main.py --historical --op nowcast_aqi mean_pm25
 
 # Past full day (>20 valid hours)
-python ./main.py --historical --fetch --clean --merge --daily
+python ./main.py --historical --daily --op nowcast_aqi mean_pm25
 # Past full week (>5 valid days)
-python ./main.py --historical --fetch --clean --merge --weekly
+python ./main.py --historical --weekly --op nowcast_aqi mean_pm25
 # Past full month (>21 valid days)
-python ./main.py --historical --fetch --clean --merge --monthly
+python ./main.py --historical --monthly --op nowcast_aqi mean_pm25
 # Past full season (>60 valid days)
-python ./main.py --historical --fetch --clean --merge --seasonal
+python ./main.py --historical --seasonal --op nowcast_aqi mean_pm25
 # Past full year (>220 valid days)
-python ./main.py --historical --fetch --clean --merge --yearly
+python ./main.py --historical --yearly --op nowcast_aqi mean_pm25
 
 # Custom date range: between 2026-01-01T00:00:00Z and now
-python ./main.py --recent --fetch --clean --merge '2026-01-01T00:00:00Z'
+python ./main.py --recent '2026-01-01T00:00:00Z' --op nowcast_aqi mean_pm25
 # Custom date range: between 2026-01-01T00:00:00Z and 2026-02-01T00:00:00Z
-python ./main.py --historical --fetch --clean --merge '2026-01-01T00:00:00Z' '2026-02-01T00:00:00Z'
+python ./main.py --historical '2026-01-01T00:00:00Z' '2026-02-01T00:00:00Z' --op nowcast_aqi mean_pm25
 ```
 
 
@@ -126,14 +126,19 @@ There are 2 different types of measurements we can fetch:
 * `--historical` Measurements occurred between start time and end time
 * `--recent` Measurements occurred between start time and now
 
-### Pipeline Stages
-There are 3 stages that will always be run in a predetermined order:
-* `--fetch` new measurement values from Clarity API. 
+### Pipeline Operations + Stages
+There are currently 2 `operations` (parameters / indicators) defined for this pipeline:
+* `nowcast_aqi` - per-hour AQI Nowcast data from Clarity, as hourly data
+* `mean_pm25` - per-minute PM2.5 data cleaned via R script from UIC, aggregated into hourly data
+
+For each operation, there are 3 (somewhat informal) stages that will always be run in a predetermined order:
+* `fetch` new measurement values from Clarity API. 
   * Also fetches and merges `locations.parquet`, since it is only returned as part of the request to fetch measurements from the API.
   * Performs and additional fetch on the Datasources API to gather the name, group, and tags for each sensor.
   * For testing if `--fetch` is not provided, the most recently fetched measurements will be used instead.
-* `--clean` the most recently fetched measurements using the R script
-  * The R script currently expects the following metrics to be part of the returned data:
+* `clean` the most recently fetched measurements using the R script
+  * The `scripts/aqi_qa_qc.R` R script performs no data cleaning, and simply aggregates hourly data into daily/weekly/monthly/seasonal/yearly averages if applicable.
+  * The `scripts/pm25_qa_qc.R` R script currently expects the following metrics to be part of the returned data:
     * `pm2_5ConcMassIndividual`
     * `relHumidInternalIndividual`
     * `temperatureInternalIndividual`
@@ -144,12 +149,15 @@ There are 3 stages that will always be run in a predetermined order:
     * `monthly`: >21 valid days to qualify as a valid monthly average
     * `seasonal`: >60 valid days to qualify as a valid seasonal average
     * `yearly`: >220 valid days to qualify as a valid yearly average
-* `--merge` the cleaned measurements into the Parquet dataset in S3
+* `merge` the cleaned measurements into the Parquet dataset in S3
+    * This stage produces a `{metric_name}.index.json` file that gives the first row index of each `type` (e.g. index of first hour, index of first day, etc)
 
 ### Resulting S3 Files
 Various Parquet datasets are produced by this process. If these files exist, their contents will be merged with any updated data received.
 
-`locations.parquet` - contains sensor lat/long, names, groups, tags, zip*, neighborhood*
+`.lock` - temporary file indicating that a process is writing to the S3 bucket. These types of collisions should be very rare.
+
+`locations.parquet` - contains sensor lat/long, names, groups, tags, zip*, neighborhood*, ward*
   * \* denotes a column that was manually added - these columns are not returned by the Clarity API
   * This is created during the `--fetch` stage (see below)
 ```bash
@@ -170,9 +178,13 @@ INFO:config:Successfully updated locations dataset!
 [280 rows x 9 columns]
 ```
 
+`{metric_name}.index.json` - a JSON map of `type` -> first row index where that type occurs
+  * One index file for each metric tracked (`nowcast_aqi` + `mean_pm25`)
+  * This is created during the `--merge` stage (see below)
+  * Index can differe between metrics, as not all metrics may have the same number of rows
 
 `{metric_name}.parquet` - contains sensor values for this metrics
-  * One Parquet file for each metric tracked (currently only `mean_pm25`)
+  * One Parquet file for each metric tracked (`nowcast_aqi` + `mean_pm25`)
   * This is created during the `--merge` stage (see below)
 ```bash
 INFO:config:Successfully updated parquet file in S3: chicago-aq/current/mean_pm25.parquet

--- a/README.md
+++ b/README.md
@@ -181,11 +181,13 @@ INFO:config:Successfully updated locations dataset!
 `{metric_name}.index.json` - a JSON map of `type` -> first row index where that type occurs
   * One index file for each metric tracked (`nowcast_aqi` + `mean_pm25`)
   * This is created during the `--merge` stage (see below)
-  * Index can differe between metrics, as not all metrics may have the same number of rows
+  * Index can differ between metrics, as not all metrics may have the same number of rows
 
-`{metric_name}.parquet` - contains sensor values for this metrics
+`{metric_name}.parquet.brotli` - contains sensor values for this metrics
   * One Parquet file for each metric tracked (`nowcast_aqi` + `mean_pm25`)
+  * Compressed using [BROTLI compression](https://parquet.apache.org/docs/file-format/data-pages/compression/)
   * This is created during the `--merge` stage (see below)
+  * Now sorted with latest hourly row first - this is to optimize the initial data fetch for the frontend
 ```bash
 INFO:config:Successfully updated parquet file in S3: chicago-aq/current/mean_pm25.parquet
 INFO:config:Successfully updated mean_pm25 dataset!
@@ -206,7 +208,7 @@ datasourceId   type                 date  DACZY2913  ...  DZLAV7766  DZTFU6199  
 ```
 
 
-These Parquet files are publicly available for download in our S3 bucket: LINK
+These Parquet files are publicly available for download in our S3 bucket: [mean_pm25.parquet.brotli](https://s3.us-east-2.amazonaws.com/chicago-aq/current/mean_pm25.parquet.brotli)  [nowcast_aqi.parquet.brotli](https://s3.us-east-2.amazonaws.com/chicago-aq/current/nowcast_aqi.parquet.brotli)
 
 
 ## Local Testing Using MinIO

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,8 @@ services:
     profiles: ["none"]
     volumes:
       - ./data:/home/rstudio/data/
+      - ./src:/home/rstudio/src/
+      - ./scripts:/home/rstudio/scripts/
     command: >
       python ./src/main.py --recent --fetch --clean --merge
 

--- a/environment.yml
+++ b/environment.yml
@@ -12,3 +12,4 @@ dependencies:
   - pyarrow
   - python-dateutil
   - duckdb
+  - PyYAML

--- a/operations.yml
+++ b/operations.yml
@@ -1,0 +1,49 @@
+
+# Key here determines output_dataset_name: {metric}.parquet.brotli
+
+mean_pm25:
+  outputFrequency: minute
+  metricSelect: 'only :pm25 + :internal'
+  minObsPerHour: '3'
+  qc: true
+  cleaningScript: ./scripts/pm25_qa_qc.R
+  postprocessing:
+    renameColumns:
+      #"pm2_5ConcMassIndividual.raw": 'mean_pm25'
+      time: 'date'
+      n_obs: 'n_valid'
+      is_valid: 'is_valid'
+      hour: 'date'
+      mean_pm25: 'mean_pm25'
+      n_valid_hours: 'n_valid'
+      is_valid_day: 'is_valid'
+      date: 'date'
+      daily_mean_pm25: 'mean_pm25'
+      n_valid_days: 'n_valid'
+      is_valid_week: 'is_valid'
+      week: 'date'
+      weekly_mean_pm25: 'mean_pm25'
+      is_valid_month: 'is_valid'
+      month: 'date'
+      monthly_mean_pm25: 'mean_pm25'
+      is_valid_season: 'is_valid'
+      season: 'date'
+      seasonal_mean_pm25: 'mean_pm25'
+      is_valid_year: 'is_valid'
+      year: 'date'
+      yearly_mean_pm25: 'mean_pm25'
+
+nowcast_aqi:
+  outputFrequency: hour
+  metricSelect: 'only *nowcast*'
+  cleaningScript: ./scripts/aqi_qa_qc.R
+
+  postprocessing:
+    renameColumns:
+      outputFrequency: 'type'
+      endOfPeriod: 'date'
+      #'pm2_5ConcMassNowcastUsEpaAqi.value': 'nowcast_aqi'
+      #'pm2_5ConcMassNowcastUsEpaAqi': 'nowcast_aqi'
+
+
+# Future: ... define new operations for NO2 + Black Carbon ...

--- a/scripts/aqi_qa_qc.R
+++ b/scripts/aqi_qa_qc.R
@@ -1,0 +1,224 @@
+library(dplyr)
+library(lubridate)
+library(tidyr)
+library(purrr)
+library(slider)
+library(arrow)
+
+# Read configuration from environment variables
+
+log_level <- Sys.getenv("LOGLEVEL", unset = "info")
+raw_minute_output_dir <- Sys.getenv("CLEANED_OUTPUT_DIR", unset = "./data/")
+
+# Read OUTPUT_FORMAT envvar - possible values are json, csv (default), parquet
+output_format <- tolower(Sys.getenv("OUTPUT_FORMAT", unset = "csv"))
+
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) < 3) {
+    cat("ERROR: Missing required argument.\n", sep = "")
+    cat("   Please specify input CSV as first script argument\n", sep = "")
+    quit(status=-1)
+}
+
+metric_name <- args[1]
+input_path <- args[2]
+output_path <- args[3]
+min_obs_per_hour <- as.integer(args[4])
+
+col_name <- "pm2_5ConcMassNowcastUsEpaAqi.value"
+
+# Compute hourly stats for ALL hours
+# Date Format:  2026-01-01 00:00:00, 2026-01-01 01:00:00, etc
+cat("Reading from input file: ",  input_path,"\n", sep = "")
+hourly <- readr::read_csv(input_path) %>%
+  mutate(date = floor_date(endOfPeriod, unit = "hour")) %>%
+  group_by(datasourceId, sourceId, date) %>%
+  summarise(
+    n_valid = sum(!is.na(.data[[col_name]])),
+    type = "hour",
+    metric = mean(.data[[col_name]], na.rm = TRUE),
+    .groups = "drop"
+  ) %>%
+  mutate(is_valid = n_valid >= min_obs_per_hour)
+
+# Keep only valid hour rows
+# Keep hours with n_obs ≥ 3 (completeness ≥ 75%)
+cat("Hourly rows (all): ", nrow(hourly), "\n")
+df_hourly <- hourly %>%
+  filter(is_valid) %>%
+  select(datasourceId, sourceId, date, metric, n_valid, is_valid) %>%
+  mutate(type = "hour") %>%
+  rename_at("metric", ~ metric_name)
+cat("Valid hourly rows (>=75% completeness): ", nrow(df_hourly), "\n")
+print(df_hourly)
+
+# Daily data
+# Daily aggregation data using only valid hours
+daily <- df_hourly %>%
+  # Date Format:  2026-01-01, 2026-01-02, etc
+  group_by(datasourceId, sourceId, date) %>%
+  mutate(date = floor_date(date, unit = "day")) %>%
+  summarise(
+    n_valid = n(),                     # Count of valid hours
+    type = "day",
+    metric = mean(get(metric_name), na.rm = TRUE),  # Mean of valid hourly means
+    .groups = "drop"
+  ) %>%
+  rename_at("metric", ~ metric_name) %>%
+  mutate(is_valid = n_valid > 20) # >20 hours
+
+# Keep only valid days
+cat("Daily rows (all): ", nrow(daily), "\n")
+df_daily <- daily %>% mutate(type = "day") %>% filter(is_valid)
+cat("Valid daily rows (>20 valid hours): ", nrow(df_daily), "\n")
+if (nrow(df_daily) > 0) {
+    print(df_daily)
+}
+
+
+# TODO: get real average code from UIC
+# stuff below is pretty much just made up
+
+
+# Weekly aggregation data using only valid days
+weekly <- df_daily %>%
+  # Date Format: 2026-W01, 2026-W02, etc
+  mutate(date = paste(lubridate::isoyear(date), sprintf("%02d", lubridate::isoweek(date)),sep = "-W")) %>%
+  group_by(datasourceId, sourceId, date) %>%
+  summarise(
+    n_valid = n(),                     # Count of valid days
+    type = "week",
+    metric = mean(get(metric_name), na.rm = TRUE),  # Mean of valid daily means
+    .groups = "drop"
+  ) %>%
+  rename_at("metric", ~ metric_name) %>%
+  mutate(is_valid = n_valid > 5) # >5 days
+
+# Keep only valid weeks
+cat("Weekly rows (all): ", nrow(weekly), "\n")
+df_weekly <- weekly %>% mutate(type = "week") %>% filter(is_valid)
+cat("Valid weekly rows (>5 valid days):" , nrow(df_weekly), "\n")
+if (nrow(df_weekly) > 0) {
+    print(df_weekly)
+}
+
+
+# Monthly aggregation data using only valid days
+# Date Format:  2026-01, 2026-02, etc
+monthly <- df_daily %>%
+  mutate(date = paste(lubridate::year(date), lubridate::month(date), sep = "-")) %>%
+  group_by(datasourceId, sourceId, date) %>%
+  summarise(
+    n_valid = n(),                     # Count of valid days
+    type = "month",
+    metric = mean(get(metric_name), na.rm = TRUE),  # Mean of valid daily means
+    .groups = "drop"
+  ) %>%
+  rename_at("metric", ~ metric_name) %>%
+  mutate(is_valid = n_valid > 21) # >21 days
+
+# Keep only valid months
+cat("Monthly rows (all): ", nrow(monthly), "\n")
+df_monthly <- monthly %>% mutate(type = "month") %>% filter(is_valid)
+cat("Valid monthly rows (>21 valid days): ", nrow(df_monthly), "\n")
+if (nrow(df_monthly) > 0) {
+    print(df_monthly)
+}
+
+# Seasonal aggregation data using only valid days
+# Date Format:  2026-summer, 2026-spring, etc
+seasonal <- df_daily %>%
+  mutate(date = case_match(month(floor_date(date, "month")),
+     1 ~ paste(lubridate::year(date), "winter", sep = "-"),
+     2 ~ paste(lubridate::year(date), "winter", sep = "-"),
+     3 ~ paste(lubridate::year(date), "spring", sep = "-"),
+     4 ~ paste(lubridate::year(date), "spring", sep = "-"),
+     5 ~ paste(lubridate::year(date), "spring", sep = "-"),
+     6 ~ paste(lubridate::year(date), "summer", sep = "-"),
+     7 ~ paste(lubridate::year(date), "summer", sep = "-"),
+     8 ~ paste(lubridate::year(date), "summer", sep = "-"),
+     9 ~ paste(lubridate::year(date), "autumn", sep = "-"),
+     10 ~ paste(lubridate::year(date), "autumn", sep = "-"),
+     11 ~ paste(lubridate::year(date), "autumn", sep = "-"),
+     12 ~ paste(lubridate::year(date)+1, "winter", sep = "-"))
+  ) %>% group_by(datasourceId, sourceId, date) %>%
+  summarise(
+    n_valid = n(),                     # Count of valid days
+    type = "season",
+    metric = mean(get(metric_name), na.rm = TRUE),  # Mean of valid daily means
+    .groups = "drop"
+  ) %>%
+  rename_at("metric", ~ metric_name) %>%
+  mutate(is_valid = n_valid > 60) # >60 days
+
+# Keep only valid seasons
+cat("Seasonal rows (all): ", nrow(seasonal), "\n")
+df_seasonal <- seasonal %>% mutate(type = "season") %>% filter(is_valid)
+cat("Valid seasonal rows (>60 valid days): ", nrow(df_seasonal), "\n")
+if (nrow(df_seasonal) > 0) {
+    print(df_seasonal)
+}
+
+# Yearly aggregation data using only valid days
+# Date Format:  2026, 2025, etc
+yearly <- df_daily %>%
+  mutate(date = lubridate::year(floor_date(date))) %>%
+  group_by(datasourceId, sourceId, date) %>%
+  summarise(
+    n_valid = n(),                     # Count of valid days
+    type = "year",
+    metric = mean(get(metric_name), na.rm = TRUE),  # Mean of valid daily means
+    .groups = "drop"
+  ) %>%
+  rename_at("metric", ~ metric_name) %>%
+  mutate(is_valid = n_valid > 250) # >250 days
+
+# Keep only valid years
+cat("Yearly rows (all): ", nrow(yearly), "\n")
+df_yearly <- yearly %>% mutate(type = "year") %>% filter(is_valid)
+cat("Valid yearly rows (>220 valid days): ", nrow(df_yearly), "\n")
+if (nrow(df_yearly) > 0) {
+    print(df_yearly)
+}
+
+# Per-sensor completeness summary
+# For each sensor
+# hours_total: total number of hourly records (including invalid hours)
+# hours_valid: number of hours that meet the completeness criterion (i.e., n_obs >= min_obs_per_hour,so is_valid_hour == TRUE)
+# pct_valid: percentage of valid hours out of total hours
+sensor_hourly_comp <- hourly %>%
+  group_by(datasourceId, sourceId) %>%
+  summarise(
+    hours_total = n(),
+    hours_valid = sum(is_valid),
+    pct_valid   = 100 * hours_valid / pmax(hours_total, 1),
+    .groups = "drop"
+  )
+
+cat("Sensor completeness summary:", nrow(sensor_hourly_comp), "sensors\n")
+print(head(sensor_hourly_comp))
+
+# Build up file name based on dataframe name + output_format (default=csv)
+# summary_completeness_file <- "summary-completeness.csv"
+
+# Merge all rows into a single dataframe
+# df_combined_final <- rbind(df_yearly, df_seasonal)
+# df_combined_final <- rbind(df_combined_final, df_monthly)
+# df_combined_final <- rbind(df_combined_final, df_weekly)
+# df_combined_final <- rbind(df_combined_final, df_daily)
+# df_combined_final <- rbind(df_combined_final, df_hourly)
+df_combined_final <- rbind(df_daily, df_hourly)
+
+# Write the chosen format to disk
+cat("Writing as OUTPUT_FORMAT=", output_format, " format: ", output_path, "\n", sep = "")
+if (output_format == "parquet") {
+    write_parquet(x = df_combined_final, sink = output_path)
+} else if (output_format == "csv") {
+    write.csv(df_combined_final, output_path, row.names = FALSE)
+} else if (output_format == "json") {
+    jsonlite::write_json(df_combined_final, output_path, pretty = FALSE)
+} else {
+    cat("Skipping writing unknown file format: \"", output_format, "\"\n", sep = "")
+}
+
+cat("Data cleanup finished successfully!\n")

--- a/scripts/aqi_qa_qc.R
+++ b/scripts/aqi_qa_qc.R
@@ -22,8 +22,7 @@ if (length(args) < 3) {
 
 metric_name <- args[1]
 input_path <- args[2]
-output_path <- args[3]
-min_obs_per_hour <- as.integer(args[4])
+min_obs_per_hour <- as.integer(args[3])
 
 col_name <- "pm2_5ConcMassNowcastUsEpaAqi.value"
 
@@ -199,26 +198,43 @@ cat("Sensor completeness summary:", nrow(sensor_hourly_comp), "sensors\n")
 print(head(sensor_hourly_comp))
 
 # Build up file name based on dataframe name + output_format (default=csv)
-# summary_completeness_file <- "summary-completeness.csv"
-
-# Merge all rows into a single dataframe
-# df_combined_final <- rbind(df_yearly, df_seasonal)
-# df_combined_final <- rbind(df_combined_final, df_monthly)
-# df_combined_final <- rbind(df_combined_final, df_weekly)
-# df_combined_final <- rbind(df_combined_final, df_daily)
-# df_combined_final <- rbind(df_combined_final, df_hourly)
-df_combined_final <- rbind(df_daily, df_hourly)
+#summary_completeness_file <- paste(raw_minute_output_dir, "mean_pm25-summary-completeness.", output_format, sep = "")
+summery_hourly_file <- paste(raw_minute_output_dir, metric_name, "-summary-hourly.", output_format, sep = "")
+summary_daily_file <- paste(raw_minute_output_dir, metric_name, "-summary-daily.", output_format, sep = "")
+summary_weekly_file <- paste(raw_minute_output_dir, metric_name, "-summary-weekly.", output_format, sep = "")
+summary_monthly_file <- paste(raw_minute_output_dir, metric_name, "-summary-monthly.", output_format, sep = "")
+summary_seasonal_file <- paste(raw_minute_output_dir, metric_name, "-summary-seasonal.", output_format, sep = "")
+summary_yearly_file <- paste(raw_minute_output_dir, metric_name, "-summary-yearly.", output_format, sep = "")
 
 # Write the chosen format to disk
-cat("Writing as OUTPUT_FORMAT=", output_format, " format: ", output_path, "\n", sep = "")
+cat("Writing as OUTPUT_FORMAT=", output_format, " format...\n", sep = "")
 if (output_format == "parquet") {
-    write_parquet(x = df_combined_final, sink = output_path)
+    #write_parquet(x = sensor_hourly_comp, sink = summary_completeness_file)
+    write_parquet(x = df_hourly, sink = summery_hourly_file)
+    write_parquet(x = df_daily, sink = summary_daily_file)
+    write_parquet(x = df_weekly, sink = summary_weekly_file)
+    write_parquet(x = df_monthly, sink = summary_monthly_file)
+    write_parquet(x = df_seasonal, sink = summary_seasonal_file)
+    write_parquet(x = df_yearly, sink = summary_yearly_file)
 } else if (output_format == "csv") {
-    write.csv(df_combined_final, output_path, row.names = FALSE)
+    #write.csv(sensor_hourly_comp, summary_completeness_file, row.names = FALSE)
+    write.csv(df_hourly, summery_hourly_file, row.names = FALSE)
+    write.csv(df_daily, summary_daily_file, row.names = FALSE)
+    write.csv(df_weekly, summary_weekly_file, row.names = FALSE)
+    write.csv(df_monthly, summary_monthly_file, row.names = FALSE)
+    write.csv(df_seasonal, summary_seasonal_file, row.names = FALSE)
+    write.csv(df_yearly, summary_yearly_file, row.names = FALSE)
 } else if (output_format == "json") {
-    jsonlite::write_json(df_combined_final, output_path, pretty = FALSE)
+    #jsonlite::write_json(sensor_hourly_comp, summary_completeness_file, pretty = FALSE)
+    jsonlite::write_json(df_hourly, summery_hourly_file, pretty = FALSE)
+    jsonlite::write_json(df_daily, summary_daily_file, pretty = FALSE)
+    jsonlite::write_json(df_weekly, summary_weekly_file, pretty = FALSE)
+    jsonlite::write_json(df_monthly, summary_monthly_file, pretty = FALSE)
+    jsonlite::write_json(df_seasonal, summary_seasonal_file, pretty = FALSE)
+    jsonlite::write_json(df_yearly, summary_yearly_file, pretty = FALSE)
 } else {
     cat("Skipping writing unknown file format: \"", output_format, "\"\n", sep = "")
 }
+
 
 cat("Data cleanup finished successfully!\n")

--- a/scripts/pm25_qa_qc.R
+++ b/scripts/pm25_qa_qc.R
@@ -16,19 +16,19 @@ output_format <- tolower(Sys.getenv("OUTPUT_FORMAT", unset = "csv"))
 args <- commandArgs(trailingOnly = TRUE)
 if (length(args) == 0) {
     cat("ERROR: Missing required argument.\n", sep = "")
-    cat("   Please specify either --recent or --historical\n", sep = "")
+    cat("   Please specify input CSV as first script argument\n", sep = "")
     quit(status=-1)
-} else if (args[1] == "--recent") {
-    cat("Cleaning recent sensor measurement data...\n", sep = "")
-    raw_input_path <- Sys.getenv("RECENT_RAW_INPUT_PATH", unset = "./data/raw-measurements-recent.csv")
-} else if (args[1] == "--historical") {
-    cat("Cleaning historical sensor measurement data...\n", sep = "")
-    raw_input_path <- Sys.getenv("HISTORICAL_RAW_INPUT_PATH", unset = "./data/raw-measurements-historical.csv")
-} else {
-    cat("ERROR: Unrecognized argument: ", args[1], "\n", sep = "")
-    raw_input_path <- Sys.getenv("RAW_INPUT_PATH", unset = "./data/raw-measurements-historical.csv")
 }
 
+raw_input_path <- args[2]
+output_path <- args[3]
+
+# Hourly data
+# Keep the hours only if it has >=3 valid minute recordings
+# Meet the completeness criterion (completeness >= 75%)
+min_obs_per_hour <- as.integer(args[4])
+
+cat("Reading from input file: ",  raw_input_path,"\n", sep = "")
 
 # Script expects per-minute data in csv-wide format
 df <- readr::read_csv(raw_input_path)
@@ -452,15 +452,9 @@ sensor_hourly_comp <- hourly %>%
 cat("Sensor completeness summary:", nrow(sensor_hourly_comp), "sensors\n")
 print(head(sensor_hourly_comp))
 
-# Build up file name based on dataframe name + output_format (default=parquet)
+# Build up file name based on dataframe name + output_format (default=csv)
 summary_completeness_file <- paste(raw_minute_output_dir, "summary-completeness.", output_format, sep = "")
-summery_hourly_file <- paste(raw_minute_output_dir, "summary-hourly.", output_format, sep = "")
-summary_daily_file <- paste(raw_minute_output_dir, "summary-daily.", output_format, sep = "")
-summary_weekly_file <- paste(raw_minute_output_dir, "summary-weekly.", output_format, sep = "")
-summary_monthly_file <- paste(raw_minute_output_dir, "summary-monthly.", output_format, sep = "")
-summary_seasonal_file <- paste(raw_minute_output_dir, "summary-seasonal.", output_format, sep = "")
-summary_yearly_file <- paste(raw_minute_output_dir, "summary-yearly.", output_format, sep = "")
-summary_combined_file <- paste(raw_minute_output_dir, "summary-combined.", output_format, sep = "")
+summary_combined_file <- output_path
 
 # Merge all rows into a single dataframe
 df_combined_final <- rbind(df_yearly, df_seasonal)
@@ -473,31 +467,13 @@ df_combined_final <- rbind(df_combined_final, df_hourly)
 # Write the chosen format to disk
 cat("Writing as OUTPUT_FORMAT=", output_format, " format...\n", sep = "")
 if (output_format == "parquet") {
-    write_parquet(x = sensor_hourly_comp, sink = summary_completeness_file)
-    write_parquet(x = df_hourly, sink = summery_hourly_file)
-    write_parquet(x = df_daily, sink = summary_daily_file)
-    write_parquet(x = df_weekly, sink = summary_weekly_file)
-    write_parquet(x = df_monthly, sink = summary_monthly_file)
-    write_parquet(x = df_seasonal, sink = summary_seasonal_file)
-    write_parquet(x = df_yearly, sink = summary_yearly_file)
+    #write_parquet(x = sensor_hourly_comp, sink = summary_completeness_file)
     write_parquet(x = df_combined_final, sink = summary_combined_file)
 } else if (output_format == "csv") {
-    write.csv(sensor_hourly_comp, summary_completeness_file, row.names = FALSE)
-    write.csv(df_hourly, summery_hourly_file, row.names = FALSE)
-    write.csv(df_daily, summary_daily_file, row.names = FALSE)
-    write.csv(df_weekly, summary_weekly_file, row.names = FALSE)
-    write.csv(df_monthly, summary_monthly_file, row.names = FALSE)
-    write.csv(df_seasonal, summary_seasonal_file, row.names = FALSE)
-    write.csv(df_yearly, summary_yearly_file, row.names = FALSE)
+    #write.csv(sensor_hourly_comp, summary_completeness_file, row.names = FALSE)
     write.csv(df_combined_final, summary_combined_file, row.names = FALSE)
 } else if (output_format == "json") {
-    jsonlite::write_json(sensor_hourly_comp, summary_completeness_file, pretty = FALSE)
-    jsonlite::write_json(df_hourly, summery_hourly_file, pretty = FALSE)
-    jsonlite::write_json(df_daily, summary_daily_file, pretty = FALSE)
-    jsonlite::write_json(df_weekly, summary_weekly_file, pretty = FALSE)
-    jsonlite::write_json(df_monthly, summary_monthly_file, pretty = FALSE)
-    jsonlite::write_json(df_seasonal, summary_seasonal_file, pretty = FALSE)
-    jsonlite::write_json(df_yearly, summary_yearly_file, pretty = FALSE)
+    #jsonlite::write_json(sensor_hourly_comp, summary_completeness_file, pretty = FALSE)
     jsonlite::write_json(df_combined_final, summary_combined_file, pretty = FALSE)
 } else {
     cat("Skipping writing unknown file format: \"", output_format, "\"\n", sep = "")

--- a/scripts/pm25_qa_qc.R
+++ b/scripts/pm25_qa_qc.R
@@ -20,18 +20,18 @@ if (length(args) == 0) {
     quit(status=-1)
 }
 
-raw_input_path <- args[2]
-output_path <- args[3]
+metric_name <- args[1]
+input_path <- args[2]
+min_obs_per_hour <- as.integer(args[3])
 
 # Hourly data
 # Keep the hours only if it has >=3 valid minute recordings
 # Meet the completeness criterion (completeness >= 75%)
-min_obs_per_hour <- as.integer(args[4])
 
-cat("Reading from input file: ",  raw_input_path,"\n", sep = "")
+cat("Reading from input file: ",  input_path,"\n", sep = "")
 
 # Script expects per-minute data in csv-wide format
-df <- readr::read_csv(raw_input_path)
+df <- readr::read_csv(input_path)
 
 # Step 1
 # PM2.5 measurements
@@ -452,10 +452,6 @@ sensor_hourly_comp <- hourly %>%
 cat("Sensor completeness summary:", nrow(sensor_hourly_comp), "sensors\n")
 print(head(sensor_hourly_comp))
 
-# Build up file name based on dataframe name + output_format (default=csv)
-summary_completeness_file <- paste(raw_minute_output_dir, "summary-completeness.", output_format, sep = "")
-summary_combined_file <- output_path
-
 # Merge all rows into a single dataframe
 df_combined_final <- rbind(df_yearly, df_seasonal)
 df_combined_final <- rbind(df_combined_final, df_monthly)
@@ -464,17 +460,41 @@ df_combined_final <- rbind(df_combined_final, df_daily)
 df_combined_final <- rbind(df_combined_final, df_hourly)
 
 
+# Build up file name based on dataframe name + output_format (default=csv)
+#summary_completeness_file <- paste(raw_minute_output_dir, "mean_pm25-summary-completeness.", output_format, sep = "")
+summery_hourly_file <- paste(raw_minute_output_dir, "mean_pm25-summary-hourly.", output_format, sep = "")
+summary_daily_file <- paste(raw_minute_output_dir, "mean_pm25-summary-daily.", output_format, sep = "")
+summary_weekly_file <- paste(raw_minute_output_dir, "mean_pm25-summary-weekly.", output_format, sep = "")
+summary_monthly_file <- paste(raw_minute_output_dir, "mean_pm25-summary-monthly.", output_format, sep = "")
+summary_seasonal_file <- paste(raw_minute_output_dir, "mean_pm25-summary-seasonal.", output_format, sep = "")
+summary_yearly_file <- paste(raw_minute_output_dir, "mean_pm25-summary-yearly.", output_format, sep = "")
+
 # Write the chosen format to disk
 cat("Writing as OUTPUT_FORMAT=", output_format, " format...\n", sep = "")
 if (output_format == "parquet") {
     #write_parquet(x = sensor_hourly_comp, sink = summary_completeness_file)
-    write_parquet(x = df_combined_final, sink = summary_combined_file)
+    write_parquet(x = df_hourly, sink = summery_hourly_file)
+    write_parquet(x = df_daily, sink = summary_daily_file)
+    write_parquet(x = df_weekly, sink = summary_weekly_file)
+    write_parquet(x = df_monthly, sink = summary_monthly_file)
+    write_parquet(x = df_seasonal, sink = summary_seasonal_file)
+    write_parquet(x = df_yearly, sink = summary_yearly_file)
 } else if (output_format == "csv") {
     #write.csv(sensor_hourly_comp, summary_completeness_file, row.names = FALSE)
-    write.csv(df_combined_final, summary_combined_file, row.names = FALSE)
+    write.csv(df_hourly, summery_hourly_file, row.names = FALSE)
+    write.csv(df_daily, summary_daily_file, row.names = FALSE)
+    write.csv(df_weekly, summary_weekly_file, row.names = FALSE)
+    write.csv(df_monthly, summary_monthly_file, row.names = FALSE)
+    write.csv(df_seasonal, summary_seasonal_file, row.names = FALSE)
+    write.csv(df_yearly, summary_yearly_file, row.names = FALSE)
 } else if (output_format == "json") {
     #jsonlite::write_json(sensor_hourly_comp, summary_completeness_file, pretty = FALSE)
-    jsonlite::write_json(df_combined_final, summary_combined_file, pretty = FALSE)
+    jsonlite::write_json(df_hourly, summery_hourly_file, pretty = FALSE)
+    jsonlite::write_json(df_daily, summary_daily_file, pretty = FALSE)
+    jsonlite::write_json(df_weekly, summary_weekly_file, pretty = FALSE)
+    jsonlite::write_json(df_monthly, summary_monthly_file, pretty = FALSE)
+    jsonlite::write_json(df_seasonal, summary_seasonal_file, pretty = FALSE)
+    jsonlite::write_json(df_yearly, summary_yearly_file, pretty = FALSE)
 } else {
     cat("Skipping writing unknown file format: \"", output_format, "\"\n", sep = "")
 }

--- a/src/clarity.py
+++ b/src/clarity.py
@@ -19,6 +19,9 @@ class ClarityAPI(object):
         #    - pm2_5ConcMassIndividual
         #    - relHumidInternalIndividual
         #    - temperatureInternalIndividual
+        # Future: NO2 / BlackCarbon needs R script support
+        #    -  + :no2 + :blackcarbon
+        # Future: AQI needs R script support to replace NowCast
         self.metricSelect = 'only + :pm25 + :internal'
 
         # Endpoint URLs / default headers for Clarity's API

--- a/src/historical.py
+++ b/src/historical.py
@@ -15,19 +15,19 @@ from utils import redact
 class HistoricalMeasurements(ClarityAPI):
 
     # Fetch per-minute metrics from the previous month in JSON format
-    def historical_fetch_metrics(self, start_time, end_time):
+    def historical_fetch_metrics(self, start_time, end_time, metricSelect, outputFrequency = 'minute', qc=False):
         # NOTE: Historical measurements don't support locationRounding or continuationToken
         body: dict = {
             'org': self.orgName,
             'allDatasources': True,
-            'outputFrequency': 'minute',
+            'outputFrequency': outputFrequency,
             'report': 'datasource-measurements',
             'format': 'csv-wide',
             'startTime': start_time,
             'endTime': end_time,
-            'metricSelect': self.metricSelect,
-            'qcAssessment': True,
-            'qcFlags': True,
+            'metricSelect': metricSelect,
+            'qcAssessment': qc,
+            'qcFlags': qc,
         }
 
         # WARNING: the `POST /report-requests` endpoint has a limit of 30 new reports per day
@@ -65,7 +65,7 @@ class HistoricalMeasurements(ClarityAPI):
 
 
     # Given a processed report and an output_path, return a DataFrame containing the requested report data
-    def download_report_contents(self, report_processed: dict, output_path: str):
+    def download_report_contents(self, report_processed: dict):
         #report_metadata = {}
         if 'urls' not in report_processed or not report_processed['urls']:
             log.fatal(f'Monthly data fetch was not successful : No urls in processed result - {report_processed}')

--- a/src/main.py
+++ b/src/main.py
@@ -1,13 +1,9 @@
 import argparse
 import logging
 import os
-import subprocess
 import sys
-import traceback
 
-import dateutil
 import pandas as pd
-import pyarrow as pa
 
 import yaml
 
@@ -18,7 +14,7 @@ from historical import HistoricalMeasurements
 from recent import RecentMeasurements
 from s3 import S3API
 
-from utils import run_r_script, get_previous_week_dates, combine_dataset_rows, merge_new_data, get_current_3_hours_dates, get_previous_day_dates, get_previous_month_dates, get_previous_season_dates, get_previous_year_dates
+from utils import merge_temporal_averages_to_df, run_r_script, get_previous_week_dates, combine_dataset_rows, merge_new_data, get_current_3_hours_dates, get_previous_day_dates, get_previous_month_dates, get_previous_season_dates, get_previous_year_dates
 
 
 logging.getLogger('config').setLevel(level=logging.getLevelName(LOGLEVEL))
@@ -93,11 +89,10 @@ def main(args):
             qc = op_defn['qc'] if 'qc' in op_defn else False
 
             fetched_data_path = os.path.join(LOCAL_OUTPUT_DIR, metric_name + '-raw-measurements.csv')
-            temp_data_path = os.path.join(LOCAL_OUTPUT_DIR, metric_name + '-scratch-measurements.csv')
             final_data_path = os.path.join(LOCAL_OUTPUT_DIR, metric_name + '-measurements.csv')
 
 
-            measurements_df =  None
+            #measurements_df =  None
 
             # Fetch recent measurements from the clarity API
             # Write raw metrics (uncleaned) into the output folder
@@ -107,12 +102,12 @@ def main(args):
                 log.info(f'Fetching recent measurement data from: {CLARITY_HOSTNAME}')
                 log.info(f'    Start time: {start_time}')
 
-                # Fetch and save CSV for cleaning
+                # Fetch recent measurements and save locations from them
                 clarity = RecentMeasurements(s3api=s3api)
                 recent_measurements_df, locations_df, token = clarity.recent_fetch_metrics(start_time=start_time, metricSelect=metricSelect, outputFrequency=outputFrequency, qc=qc)
                 recent_measurements_df.to_csv(fetched_data_path)
                 log.info(f'Data fetched successfully: {fetched_data_path}')
-                measurements_df = recent_measurements_df
+                #measurements_df = recent_measurements_df
                 #measurements_df = pd.read_csv(fetched_data_path) # None
 
             # Fetch recent or historical measurements from the clarity API
@@ -139,29 +134,27 @@ def main(args):
                 log.info(f'Fetching historical measurement data from: {CLARITY_HOSTNAME}')
                 log.info(f'    Start time: {start_time}')
                 log.info(f'    End time  : {end_time}')
-                #clarity = HistoricalMeasurements(s3api=s3api)
-                #report_processed = clarity.historical_fetch_metrics(start_time=start_time, end_time=end_time, metricSelect=metricSelect, outputFrequency=outputFrequency, qc=qc)
 
-                # Output metrics and run post-processing
-                # historical_report_df, locations = clarity.download_report_contents(report_processed=report_processed)
-                # historical_report_df.to_csv(fetched_data_path)
-                # log.info(f'Historical data fetched successfully: {start_time} - {end_time} -> {fetched_data_path}')
-                # measurements_df = historical_report_df
-                measurements_df = pd.read_csv(fetched_data_path) # None
+                # Fetch/poll for historical measurements and save locations from them
+                clarity = HistoricalMeasurements(s3api=s3api)
+                report_processed = clarity.historical_fetch_metrics(start_time=start_time, end_time=end_time, metricSelect=metricSelect, outputFrequency=outputFrequency, qc=qc)
+                historical_report_df, locations = clarity.download_report_contents(report_processed=report_processed)
+                historical_report_df.to_csv(fetched_data_path)
+                log.info(f'Historical data fetched successfully: {start_time} - {end_time} -> {fetched_data_path}')
+                #measurements_df = historical_report_df
+                #measurements_df = pd.read_csv(fetched_data_path) # None
 
             # Clean fetched measurements with R script (if provided)
             # Write raw metrics (uncleaned) into the output folder
-            if 'cleaningScript' in op_defn:
-                log.info(f'Cleaning up measurement data with R script: {op_defn["cleaningScript"]}...')
-                measurements_df = run_r_script(
-                    scriptPath=op_defn['cleaningScript'],
-                    inputFile=fetched_data_path,
-                    outputFile=temp_data_path,
-                    metricName=metric_name,
-                    minObsPerHour=op_defn['minObsPerHour'] if 'minObsPerHour' in op_defn else '1',
-                )
-            else:
-                log.info(f'Skipping data cleanup script (none defined for {metric_name})')
+            log.info(f'Cleaning up measurement data with R script: {op_defn["cleaningScript"]}...')
+            run_r_script(
+                scriptPath=op_defn['cleaningScript'],
+                inputFile=fetched_data_path,
+                metricName=metric_name,
+                minObsPerHour=op_defn['minObsPerHour'] if 'minObsPerHour' in op_defn else '1',
+            )
+
+            measurements_df = merge_temporal_averages_to_df(metric_name=metric_name, op_defn=op_defn)
 
             # Aggregate per-minute data to hourly average?
             # if outputFrequency == 'minute':
@@ -180,7 +173,7 @@ def main(args):
                     renameColumns = op_defn['postprocessing']['renameColumns']
                     measurements_df.rename(columns=renameColumns, inplace=True)
 
-            log.info(f'Postprocessing complete: {final_data_path}')
+            log.info(f'Post-processing complete: {final_data_path}')
             #log.info(f'Computing temporal averages...')
             measurements_df.to_csv(final_data_path)
 

--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,8 @@ import dateutil
 import pandas as pd
 import pyarrow as pa
 
+import yaml
+
 
 from datetime import datetime, UTC
 from config import log, CLARITY_HOSTNAME, LOCAL_OUTPUT_DIR, LOGLEVEL, HISTORICAL_START_TIME, HISTORICAL_END_TIME
@@ -16,7 +18,7 @@ from historical import HistoricalMeasurements
 from recent import RecentMeasurements
 from s3 import S3API
 
-from utils import get_previous_week_dates, combine_dataset_rows, merge_new_data, get_current_3_hours_dates, get_previous_day_dates, get_previous_month_dates, get_previous_season_dates, get_previous_year_dates
+from utils import run_r_script, get_previous_week_dates, combine_dataset_rows, merge_new_data, get_current_3_hours_dates, get_previous_day_dates, get_previous_month_dates, get_previous_season_dates, get_previous_year_dates
 
 
 logging.getLogger('config').setLevel(level=logging.getLevelName(LOGLEVEL))
@@ -68,198 +70,153 @@ def main(args):
         log.error('ERROR: please choose only one of  --recent (-r) or --historical (-H)')
         sys.exit(300)
 
-    # if args.weekly:
-    #     prev_week_start, prev_week_end = get_previous_week_dates()
-    #     log.info(f'Fetching weekly historical measurement data from: {CLARITY_HOSTNAME}')
-    #     log.info(f'    Start Time: {prev_week_start}')
-    #     log.info(f'    End time  : {prev_week_end}')
-    #
-    #     sys.exit(0)
+    if args.ops:
+        ops_defn_path = './operations.yml'
+        all_operations = ['mean_pm25', 'nowcast_aqi']
+        ops_to_run = all_operations if args.ops == '*' else args.ops
+        with open(ops_defn_path) as f:
+            operations = yaml.safe_load(f)
 
-    # Fetch recent measurements from the clarity API
-    # Write raw metrics (uncleaned) into the output folder
-    if args.fetch and args.recent:
-        start_of_3_hours, _ = get_current_3_hours_dates()
-        start_time = args.startTime if args.startTime else start_of_3_hours
-        log.info(f'Fetching recent measurement data from: {CLARITY_HOSTNAME}')
-        log.info(f'    Start time: {start_time}')
-        clarity = RecentMeasurements(s3api=s3api)
-        recent_measurements_df, locations_df, token = clarity.recent_fetch_metrics(start_time=start_time)
+        print('All known ops: ' + str(all_operations))
+        print('Now running: ' + str(ops_to_run))
+        print('Operations definitions: ' + str(operations))
 
-        # Save to CSV for cleaning
-        output_path = os.path.join(LOCAL_OUTPUT_DIR, 'raw-measurements-recent.csv')
-        recent_measurements_df.to_csv(output_path)
+        for metric_name in ops_to_run:
+            if metric_name not in operations:
+                print(f'ERROR: {metric_name} not defined in operations.yml')
+                continue
+            print('Running operation: ' + metric_name)
+            op_defn = operations[metric_name]
+            print('Definition: ' + str(op_defn))
+            metricSelect = op_defn['metricSelect']
+            outputFrequency = op_defn['outputFrequency']
+            qc = op_defn['qc'] if 'qc' in op_defn else False
 
-        log.info(f'Data fetched successfully: {output_path}')
-
-        if not args.clean:
-            log.warn('Data cleaning was skipping, so data cannot be merged. Aborting.')
-            sys.exit(22)
+            fetched_data_path = os.path.join(LOCAL_OUTPUT_DIR, metric_name + '-raw-measurements.csv')
+            temp_data_path = os.path.join(LOCAL_OUTPUT_DIR, metric_name + '-scratch-measurements.csv')
+            final_data_path = os.path.join(LOCAL_OUTPUT_DIR, metric_name + '-measurements.csv')
 
 
-    # Fetch historical measurements from the clarity API
-    # Write raw metrics (uncleaned) into the output folder
-    if args.fetch and args.historical:
-        start_time = args.startTime if args.startTime else HISTORICAL_START_TIME
-        end_time = args.endTime if args.endTime else HISTORICAL_END_TIME
+            measurements_df =  None
 
-        # If any helper date ranges provided, override other input methods
-        # Use largest range provided, should encompass the others
-        if args.hourly:
-            start_time, end_time = get_current_3_hours_dates()
-        if args.daily:
-            start_time, end_time = get_previous_day_dates()
-        if args.weekly:
-            start_time, end_time = get_previous_week_dates()
-        if args.monthly:
-            start_time, end_time = get_previous_month_dates()
-        if args.seasonal:
-            start_time, end_time = get_previous_season_dates()
-        if args.yearly:
-            start_time, end_time = get_previous_year_dates()
+            # Fetch recent measurements from the clarity API
+            # Write raw metrics (uncleaned) into the output folder
+            if not args.historical:
+                start_of_3_hours, _ = get_current_3_hours_dates()
+                start_time = args.startTime if args.startTime else start_of_3_hours
+                log.info(f'Fetching recent measurement data from: {CLARITY_HOSTNAME}')
+                log.info(f'    Start time: {start_time}')
 
-        log.info(f'Fetching historical measurement data from: {CLARITY_HOSTNAME}')
-        log.info(f'    Start time: {start_time}')
-        log.info(f'    End time  : {end_time}')
-        clarity = HistoricalMeasurements(s3api=s3api)
-        report_processed = clarity.historical_fetch_metrics(start_time=start_time, end_time=end_time)
+                # Fetch and save CSV for cleaning
+                clarity = RecentMeasurements(s3api=s3api)
+                recent_measurements_df, locations_df, token = clarity.recent_fetch_metrics(start_time=start_time, metricSelect=metricSelect, outputFrequency=outputFrequency, qc=qc)
+                recent_measurements_df.to_csv(fetched_data_path)
+                log.info(f'Data fetched successfully: {fetched_data_path}')
+                measurements_df = recent_measurements_df
+                #measurements_df = pd.read_csv(fetched_data_path) # None
 
-        # Output metrics and run post-processing
-        output_path = os.path.join(LOCAL_OUTPUT_DIR, 'raw-measurements-historical.csv')
-        historical_report_df, locations = clarity.download_report_contents(report_processed=report_processed, output_path=output_path)
-        historical_report_df.to_csv(output_path)
+            # Fetch recent or historical measurements from the clarity API
+            # Write raw metrics (uncleaned) into the output folder
+            else:
+                start_time = args.startTime if args.startTime else HISTORICAL_START_TIME
+                end_time = args.endTime if args.endTime else HISTORICAL_END_TIME
 
-        log.info(f'Historical data fetched successfully: {start_time} - {end_time} -> {output_path}')
+                # If any helper date ranges provided, override other input methods
+                # Use largest range provided, should encompass the others
+                if args.hourly:
+                    start_time, end_time = get_current_3_hours_dates()
+                if args.daily:
+                    start_time, end_time = get_previous_day_dates()
+                if args.weekly:
+                    start_time, end_time = get_previous_week_dates()
+                if args.monthly:
+                    start_time, end_time = get_previous_month_dates()
+                if args.seasonal:
+                    start_time, end_time = get_previous_season_dates()
+                if args.yearly:
+                    start_time, end_time = get_previous_year_dates()
 
-        if not args.clean:
-            log.warn('Data cleaning was skipping, so data cannot be merged. Aborting.')
-            sys.exit(22)
+                log.info(f'Fetching historical measurement data from: {CLARITY_HOSTNAME}')
+                log.info(f'    Start time: {start_time}')
+                log.info(f'    End time  : {end_time}')
+                #clarity = HistoricalMeasurements(s3api=s3api)
+                #report_processed = clarity.historical_fetch_metrics(start_time=start_time, end_time=end_time, metricSelect=metricSelect, outputFrequency=outputFrequency, qc=qc)
 
+                # Output metrics and run post-processing
+                # historical_report_df, locations = clarity.download_report_contents(report_processed=report_processed)
+                # historical_report_df.to_csv(fetched_data_path)
+                # log.info(f'Historical data fetched successfully: {start_time} - {end_time} -> {fetched_data_path}')
+                # measurements_df = historical_report_df
+                measurements_df = pd.read_csv(fetched_data_path) # None
 
-    # Clean fetched measurements with R script
-    # Write raw metrics (uncleaned) into the output folder
-    if args.clean:
-        log.info(f'Cleaning up measurement data with R...')
+            # Clean fetched measurements with R script (if provided)
+            # Write raw metrics (uncleaned) into the output folder
+            if 'cleaningScript' in op_defn:
+                log.info(f'Cleaning up measurement data with R script: {op_defn["cleaningScript"]}...')
+                measurements_df = run_r_script(
+                    scriptPath=op_defn['cleaningScript'],
+                    inputFile=fetched_data_path,
+                    outputFile=temp_data_path,
+                    metricName=metric_name,
+                    minObsPerHour=op_defn['minObsPerHour'] if 'minObsPerHour' in op_defn else '1',
+                )
+            else:
+                log.info(f'Skipping data cleanup script (none defined for {metric_name})')
 
-        try:
-            output = subprocess.check_output([
-                'Rscript',
-                'clarity_qa_qc.R',
-                '--historical' if args.historical else '--recent'
-            ], universal_newlines=True, stderr=subprocess.PIPE)
-            print(output.strip())
-        except subprocess.CalledProcessError as ex:
-            log.error('R script failed. Error:', ex.stderr)
-            traceback.print_exc()
-            sys.exit(500)
-        except FileNotFoundError as ex:
-            log.error('ERROR: Rscript not found.', ex)
-            traceback.print_exc()
-            sys.exit(404)
-        except Exception as ex:
-            log.error('ERROR: Rscript encountered an unknown exception: ', ex)
-            traceback.print_exc()
-            sys.exit(501)
+            # Aggregate per-minute data to hourly average?
+            # if outputFrequency == 'minute':
+            #     log.info(f'Computing hourly averages from per-minute data...')
+            #     measurements_df = run_r_script(
+            #         scriptPath='./scripts/scratch.R',
+            #         inputFile=temp_data_path,
+            #         outputFile=temp_data_path,
+            #         metricName=metric_name,
+            #         minObsPerHour=op_defn['minObsPerHour'] if 'minObsPerHour' in op_defn else '1',
+            #     )
 
-        if not args.merge:
-            log.warn('DRY RUN: --merge was not specified, so this will be treated as a dry run. Aborting.')
-            sys.exit(44)
+            if 'postprocessing' in op_defn:
+                log.info(f'Running postprocessing for: {metric_name}...')
+                if 'renameColumns' in op_defn['postprocessing']:
+                    renameColumns = op_defn['postprocessing']['renameColumns']
+                    measurements_df.rename(columns=renameColumns, inplace=True)
 
-    # Download existing parquet files from S3, merge latest data, and output the merged parquet file
-    # TODO: ignore duplicates? or overwrite? need to pick a conflict-resolution strategy
-    if args.merge:
-        # Ensure column consistency: n_valid, type, date, is_valid, mean_pm25
-        log.info(f'Compiling hourly sensor data...')
-        hourly = pd.read_csv('data/summary-hourly.csv').rename(columns={
-            'n_obs': 'n_valid',
-            'is_valid_hour': 'is_valid',
-            'hour': 'date',
-            'mean_pm25': 'mean_pm25',
-            # .. define new metrics here, use consistent column names for hourly + daily ... #
-        })
-        hourly['type'] = 'hour'
+            log.info(f'Postprocessing complete: {final_data_path}')
+            #log.info(f'Computing temporal averages...')
+            measurements_df.to_csv(final_data_path)
 
-        # TODO: Use ISO 8601 Format indicating UTC timezone? browser needs special handling otherwise
-        # Currently using something more akin to ISO 9705
-        #hourly['date'] = hourly['date'].map(lambda d: dateutil.parser.isoparse(d).isoformat() + 'Z')
+            # Compute temporal averages based on hourly data
+            # measurements_df = measurements_df[['type', 'date', 'datasourceId', 'sourceId', 'nowcast_aqi']]
+            # dt_index = pd.to_datetime(measurements_df['date'])
+            # measurements_df.date.index = dt_index.map(lambda x: x.isoformat())
+            # measurements_df.set_index(['type', 'date', 'datasourceId', 'sourceId'], inplace=True)
 
-        # Ensure column consistency: n_valid, type, date, is_valid, mean_pm2
-        log.info(f'Compiling daily sensor data...')
-        daily = pd.read_csv('data/summary-daily.csv').rename(columns={
-            'n_valid_hours': 'n_valid',
-            'is_valid_day': 'is_valid',
-            'date': 'date',
-            'daily_mean_pm25': 'mean_pm25',
-            # .. define new metrics here, use consistent column names for hourly + daily ... #
-        })
-        daily['type'] = 'day'
+            print(measurements_df)
+            #
+            # daily = (measurements_df
+            #              .groupby(['type', 'datasourceId', 'sourceId'])
+            #              .resample('D', level='date').mean())
+            # weekly = (measurements_df
+            #              .groupby(['type', 'datasourceId', 'sourceId'])
+            #              .resample('W', level='date').mean())
+            # monthly = (measurements_df
+            #              .groupby(['type', 'datasourceId', 'sourceId'])
+            #              .resample('ME', level='date').mean())
+            # yearly = (measurements_df
+            #              .groupby(['type', 'datasourceId', 'sourceId'])
+            #              .resample('YE', level='date').mean())
+            # print('Daily:', daily)
+            # print('Weekly:', weekly)
+            # print('Monthly:', monthly)
+            # print('Yearly:', yearly)
 
-        # Ensure column consistency: n_valid, type, date, is_valid, mean_pm2
-        log.info(f'Compiling weekly sensor data...')
-        weekly = pd.read_csv('data/summary-weekly.csv').rename(columns={
-            'n_valid_days': 'n_valid',
-            'is_valid_week': 'is_valid',
-            'week': 'date',
-            'weekly_mean_pm25': 'mean_pm25',
-            # .. define new metrics here, use consistent column names for hourly + daily ... #
-        })
-        weekly['type'] = 'week'
-
-        # Ensure date in the correct format - 2025-W10, 2025-W09, etc
-        weekly['date'] = weekly['date'].map(lambda d: d.split('-')[0]+'-W'+d.split('-')[1][1:].zfill(2))
-
-        # Ensure column consistency: n_valid, type, date, is_valid, mean_pm2
-        log.info(f'Compiling monthly sensor data...')
-        monthly = pd.read_csv('data/summary-monthly.csv').rename(columns={
-            'n_valid_days': 'n_valid',
-            'is_valid_month': 'is_valid',
-            'month': 'date',
-            'monthly_mean_pm25': 'mean_pm25',
-            # .. define new metrics here, use consistent column names for hourly + daily ... #
-        })
-        monthly['type'] = 'month'
-
-        # Ensure date in the correct format - 2025-10, 2025-09, etc
-        monthly['date'] = monthly['date'].map(lambda d: d.split('-')[0]+'-'+d.split('-')[1].zfill(2))
-
-
-        # Ensure column consistency: n_valid, type, date, is_valid, mean_pm2
-        log.info(f'Compiling seasonal sensor data...')
-        seasonal = pd.read_csv('data/summary-seasonal.csv').rename(columns={
-            'n_valid_days': 'n_valid',
-            'is_valid_season': 'is_valid',
-            'season': 'date',
-            'seasonal_mean_pm25': 'mean_pm25',
-            # .. define new metrics here, use consistent column names for hourly + daily ... #
-        })
-        seasonal['type'] = 'season'
-
-        # Ensure date in the correct format - 2025-S03, 2025-S02, etc
-        seasonal['date'] = seasonal['date'].map(lambda d: d.split('-')[0]+'-'+d.split('-')[1][1:].zfill(2))
-
-        # Ensure column consistency: n_valid, type, date, is_valid, mean_pm2
-        log.info(f'Compiling yearly sensor data...')
-        yearly = pd.read_csv('data/summary-yearly.csv').rename(columns={
-            'n_valid_days': 'n_valid',
-            'is_valid_season': 'is_valid',
-            'season': 'date',
-            'yearly_mean_pm25': 'mean_pm25',
-            # .. define new metrics here, use consistent column names for hourly + daily ... #
-        })
-        yearly['type'] = 'year'
-
-        # Concatenate all rows of different types into single dataframe
-        merged_sensor_df = pd.concat([yearly, seasonal, monthly, weekly, daily, hourly])
-
-        # Repeat this process process each
-        # TODO: Support other metrics?
-        for metric in ['mean_pm25']:
-            log.info(f'Pivoting data for {metric}.parquet')
-            new_sensor_df = pd.pivot_table(data=merged_sensor_df, values=metric, index=['type', 'date'], columns=['datasourceId'], aggfunc='last', dropna=True)
+            # Repeat this process for each metric
+            log.info(f'Pivoting data for {metric_name}.parquet')
+            new_sensor_df = pd.pivot_table(data=measurements_df, values=metric_name, index=['type', 'date'], columns=['datasourceId'], aggfunc='last', dropna=True)
             new_sensor_df = new_sensor_df.rename(columns={'datasourceId': ''}).reset_index()
 
+
             s3api.update_measurements_df(
-                metric_name=metric,
+                metric_name=metric_name,
                 new_measurements_df=new_sensor_df,
             )
 
@@ -293,7 +250,8 @@ if __name__ == '__main__':
     parser.add_argument('-m', '--merge', action='store_true',
                         help="Merge new date into existing parquet dataset in S3 (MinIO or AWS S3)")
 
-    # Admin / Debug commands
+    # Admin / Debug
+    parser.add_argument('-o', '--ops', nargs='*', default=None, help="Run operations as defined in operations.yml")
     parser.add_argument('-b', '--backup', action='store_true',
                         help="Backup existing parquet files in S3")
     parser.add_argument('--hourly', action='store_true',

--- a/src/recent.py
+++ b/src/recent.py
@@ -1,4 +1,6 @@
 import json
+
+import pandas as pd
 import requests
 import sys
 
@@ -10,7 +12,7 @@ from utils import redact
 # globals: S3_BUCKET_NAME, CLARITY_API_KEY, CLARITY_ORG_NAME, CONTINUATION_TOKEN_OUTPUT_PATH, s3_client
 class RecentMeasurements(ClarityAPI):
 
-    def recent_post_measurements_query(self, start_time):
+    def recent_post_measurements_query(self, start_time, metricSelect, outputFrequency = 'minute', qc=False):
         token = self.read_continuation_token()
         body: dict = { 'org': self.orgName, 'continuationToken': token } \
             if CLARITY_USE_CONTINUATION_TOKEN and token else \
@@ -18,11 +20,13 @@ class RecentMeasurements(ClarityAPI):
                 'org': self.orgName,
                 'allDatasources': True,
                 'replyWithContinuationToken': CLARITY_USE_CONTINUATION_TOKEN,
-                'outputFrequency': 'minute',
+                'outputFrequency': outputFrequency,
                 'locationRounding': 4,
                 'format': 'csv-wide',
                 'startTime': start_time if start_time else None,
-                'metricSelect': self.metricSelect,
+                'metricSelect': metricSelect,
+                'qcAssessment': qc,
+                'qcFlags': qc,
             }
 
         url = self.continuationUrl if token else self.measurementsUrl
@@ -46,20 +50,21 @@ class RecentMeasurements(ClarityAPI):
         if CLARITY_USE_CONTINUATION_TOKEN and token:
             return self.s3api.update_continuation_token(token=token)
         elif CLARITY_USE_CONTINUATION_TOKEN:
-            log.warn('WARNING: no continuation_token to write, but CLARITY_USE_CONTINUATION_TOKEN. Query will not continue the next time unless the token is saved.')
+            log.warning('WARNING: no continuation_token to write, but CLARITY_USE_CONTINUATION_TOKEN. Query will not continue the next time unless the token is saved.')
 
 
     # Example: curl https://clarity-data-api.clarity.io/v2/recent-datasource-measurements-query -H 'Content-Type: application/json' -H 'x-api-key: ${CLARITY_API_KEY}' -H 'Accept: application/json' -d '{'org':'cityof58A9','allDatasources':true,'replyWithContinuationToken':true,'outputFrequency':'hour','format':'csv-wide'}' -vvvv
     # Fetch per-hour metrics from the past 24 hours in JSON format
-    def recent_fetch_metrics(self, start_time):
+    def recent_fetch_metrics(self, start_time, metricSelect, outputFrequency, qc=False):
         try:
-            r = self.recent_post_measurements_query(start_time=start_time)
-            recent_measurements_df = self.parse_results_csv_wide(r=r)
-            locations_df = self.gather_locations(measurements_df=recent_measurements_df)
+            # Fetch per-minute PM2.5 metrics
+            resp = self.recent_post_measurements_query(start_time=start_time, metricSelect=metricSelect, outputFrequency=outputFrequency, qc=qc)
+            measurements_df = self.parse_results_csv_wide(r=resp)
+            locations_df = self.gather_locations(measurements_df=measurements_df)
             self.s3api.update_locations_df(new_locations_df=locations_df)
 
-            token = r.headers.get('x-clarity-continuation-token', None)
-            return recent_measurements_df, locations_df, token
+            token = resp.headers.get('x-clarity-continuation-token', resp.headers.get('x-clarity-continuation-token', None))
+            return measurements_df, locations_df, token
 
         except requests.exceptions.ConnectionError as ex:
             self.log_exception(ex, 'Connection Error: Could not connect to the server')

--- a/src/s3.py
+++ b/src/s3.py
@@ -64,7 +64,7 @@ class S3API(object):
     # Acquire a lock for writing to the dataset
     # Use this to prevent multiple processes from writing to the dataset simultaneously
     # And don't forget to call unlock when you're done! :)
-    def lock(self, wait=False):
+    def lock(self, wait=True):
         # Check if lockfile exists
         log.debug('Acquiring lockfile...')
         lockfile_path = f'{S3_BUCKET_NAME}/.lock'
@@ -101,6 +101,29 @@ class S3API(object):
         return True
 
 
+    # Produce an index file to tell the frontend the index of the first row of each "type"
+    # WARNING: Acquire the lock BEFORE calling. This index is produced as new metrics are updated
+    def update_index(self, merged_df, metric_name):
+        df = merged_df.reset_index()
+        index_path = f'{S3_BUCKET_NAME}/current/{metric_name}.index.json'
+        log.debug(f'Writing {index_path}...')
+        index = json.dumps({
+            'hour': (df['type'] == 'hour').idxmax(),
+            'day': (df['type'] == 'day').idxmax(),
+            'week': (df['type'] == 'week').idxmax(),
+            'month': (df['type'] == 'month').idxmax(),
+            'season': (df['type'] == 'season').idxmax(),
+            'year': (df['type'] == 'year').idxmax()
+        })
+
+        try:
+            self.write_file(path=index_path, contents=index, overwrite=True)
+            log.debug(f'Successfully wrote {index_path}: {index}')
+        except Exception as e:
+            log.error(f'Failed to write index file {index_path}: {e}')
+            log.error(traceback.format_exc())
+
+
     # Given a metric name and a dataframe of new sensor data for that metric,
     #   - Acquire the lock to claim exclusive write access to the data
     #   - Merge with our existing parquet dataset, create a new one if it doesn't exist
@@ -135,6 +158,7 @@ class S3API(object):
                 merged_df = merge_new_data(existing_df=pd.DataFrame(columns=['type', 'date']), data_to_merge=new_measurements_df)
 
             self.write_file(path=metric_df_path, contents=merged_df, file_format='parquet', binary=True, overwrite=True)
+            self.update_index(metric_name=metric_name, merged_df=merged_df)
             log.info(f'Successfully updated {metric_name} dataset!')
             print(merged_df)
         except Exception as e:

--- a/src/s3.py
+++ b/src/s3.py
@@ -145,6 +145,9 @@ class S3API(object):
             # Release lockfile when done writing
             self.unlock()
 
+    def merge_locstions_df(self, existing_df, nee_df2):
+        columns = ['datasourceId', 'sourceId']
+        return nee_df2.set_index(columns).combine_first(existing_df).sort_values(by=columns, ascending=True).reset_index()
 
     # Merged lat/lon coordinates into our list of known sensorIds
     #   - Acquire the lock to claim exclusive write access to the data
@@ -164,7 +167,7 @@ class S3API(object):
 
         try:
             existing_df = self.read_dataset(df_path=locations_df_path, columns=columns).set_index(columns)
-            merged_df = new_locations_df.set_index(columns).combine_first(existing_df).sort_values(by=columns, ascending=True).reset_index()
+            merged_df = self.merge_locstions_df(existing_df, new_locations_df)
             self.write_file(path=locations_df_path, contents=merged_df, file_format='parquet', binary=True, overwrite=True)
             log.info('Successfully updated locations dataset!')
             print(merged_df)

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,14 +1,22 @@
 import json
+import os
+import subprocess
+import sys
+import traceback
 from decimal import Decimal
 
 # timedelta for microseconds/days/hours, relativedelta for months/years
 from datetime import datetime, UTC, timedelta
+from typing import Any
+
 from dateutil.relativedelta import relativedelta
 
 import duckdb
 import pandas as pd
 from pandas import DataFrame
 from pathlib import Path
+
+from config import log, LOCAL_OUTPUT_DIR
 
 # For Pandas > 3.0.0, DType==string is not yet well-supported
 pd.options.future.infer_string = False
@@ -171,7 +179,33 @@ def get_current_year_dates():
 def truncate(full_str: str|list[any], limit = 20):
     return f'{full_str[:limit]}...' if len(full_str) > limit else full_str
 
-def redact(redactable: any, key_name: str = '', limit = 20):
+def run_r_script(scriptPath: str, inputFile: str, outputFile: str, metricName: str, minObsPerHour: int):
+    try:
+        output = subprocess.check_output([
+            'Rscript',
+            scriptPath,
+            metricName,
+            inputFile,
+            outputFile,
+            minObsPerHour
+        ], universal_newlines=True, stderr=subprocess.PIPE)
+        print(output.strip())
+
+        return pd.read_csv(outputFile)
+    except subprocess.CalledProcessError as ex:
+        log.error('R script failed. Error:', ex.stderr)
+        traceback.print_exc()
+        sys.exit(500)
+    except FileNotFoundError as ex:
+        log.error('ERROR: File not found.', ex)
+        traceback.print_exc()
+        sys.exit(404)
+    except Exception as ex:
+        log.error('ERROR: Rscript encountered an unknown exception: ', ex)
+        traceback.print_exc()
+        sys.exit(501)
+
+def redact(redactable: Any, key_name: str = '', limit = 20):
     if isinstance(redactable, dict):
         # Create a deep copy of input object
         if key_name == '':

--- a/src/utils.py
+++ b/src/utils.py
@@ -325,7 +325,7 @@ def merge_new_data(existing_df, data_to_merge):
     merged_df['date'] = merged_df['date'].astype('str')
 
     # Sort by type, then reverse sort by date for optimal retrieval of latest metrics
-    merged_df.sort_values(by=['type','date'], ascending=[True, False], inplace=True)
+    merged_df.sort_values(by=['type','date'], ascending=[False, False], inplace=True)
     return merged_df
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -179,19 +179,17 @@ def get_current_year_dates():
 def truncate(full_str: str|list[any], limit = 20):
     return f'{full_str[:limit]}...' if len(full_str) > limit else full_str
 
-def run_r_script(scriptPath: str, inputFile: str, outputFile: str, metricName: str, minObsPerHour: int):
+def run_r_script(scriptPath: str, inputFile: str, metricName: str, minObsPerHour: int):
     try:
         output = subprocess.check_output([
             'Rscript',
             scriptPath,
             metricName,
             inputFile,
-            outputFile,
             minObsPerHour
         ], universal_newlines=True, stderr=subprocess.PIPE)
         print(output.strip())
 
-        return pd.read_csv(outputFile)
     except subprocess.CalledProcessError as ex:
         log.error('R script failed. Error:', ex.stderr)
         traceback.print_exc()
@@ -204,6 +202,59 @@ def run_r_script(scriptPath: str, inputFile: str, outputFile: str, metricName: s
         log.error('ERROR: Rscript encountered an unknown exception: ', ex)
         traceback.print_exc()
         sys.exit(501)
+
+
+def merge_temporal_averages_to_df(metric_name, op_defn):
+    # TODO: hard-coded paths? is this ok?
+    renameColumns = op_defn['renameColumns'] if 'renameColumns' in op_defn else {}
+
+
+    # Ensure column consistency: n_valid, type, date, is_valid, mean_pm25
+    log.info(f'Compiling hourly sensor data...')
+    hourly = pd.read_csv(f'data/{metric_name}-summary-hourly.csv').rename(columns=renameColumns)
+    hourly['type'] = 'hour'
+
+    # TODO: Use ISO 8601 Format indicating UTC timezone? browser needs special handling otherwise
+    # Currently using something more akin to ISO 9705
+    # hourly['date'] = hourly['date'].map(lambda d: dateutil.parser.isoparse(d).isoformat() + 'Z')
+
+    # Ensure column consistency: n_valid, type, date, is_valid, mean_pm2
+    log.info(f'Compiling daily sensor data...')
+    daily = pd.read_csv(f'data/{metric_name}-summary-daily.csv').rename(columns=renameColumns)
+    daily['type'] = 'day'
+
+    # Ensure column consistency: n_valid, type, date, is_valid, mean_pm2
+    log.info(f'Compiling weekly sensor data...')
+    weekly = pd.read_csv(f'data/{metric_name}-summary-weekly.csv').rename(columns=renameColumns)
+    weekly['type'] = 'week'
+
+    # Ensure date in the correct format - 2025-W10, 2025-W09, etc
+    weekly['date'] = weekly['date'].map(lambda d: d.split('-')[0] + '-W' + d.split('-')[1][1:].zfill(2))
+
+    # Ensure column consistency: n_valid, type, date, is_valid, mean_pm2
+    log.info(f'Compiling monthly sensor data...')
+    monthly = pd.read_csv(f'data/{metric_name}-summary-monthly.csv').rename(columns=renameColumns)
+    monthly['type'] = 'month'
+
+    # Ensure date in the correct format - 2025-10, 2025-09, etc
+    monthly['date'] = monthly['date'].map(lambda d: d.split('-')[0] + '-' + d.split('-')[1].zfill(2))
+
+    # Ensure column consistency: n_valid, type, date, is_valid, mean_pm2
+    log.info(f'Compiling seasonal sensor data...')
+    seasonal = pd.read_csv(f'data/{metric_name}-summary-seasonal.csv').rename(columns=renameColumns)
+    seasonal['type'] = 'season'
+
+    # Ensure date in the correct format - 2025-S03, 2025-S02, etc
+    seasonal['date'] = seasonal['date'].map(lambda d: d.split('-')[0] + '-' + d.split('-')[1][1:].zfill(2))
+
+    # Ensure column consistency: n_valid, type, date, is_valid, mean_pm2
+    log.info(f'Compiling yearly sensor data...')
+    yearly = pd.read_csv(f'data/{metric_name}-summary-yearly.csv').rename(columns=renameColumns)
+    yearly['type'] = 'year'
+
+    # Concatenate all rows of different types into single dataframe
+    return pd.concat([yearly, seasonal, monthly, weekly, daily, hourly])
+
 
 def redact(redactable: Any, key_name: str = '', limit = 20):
     if isinstance(redactable, dict):


### PR DESCRIPTION
## Problem
We are only using per-minute data right now, but Nowcast AQI was requested. Unfortunately, Nowcast AQI is only available in per-hour data, and is not provided when querying for `outputFrequency=minute`

We need a more flexible system to accommodate these types of requests

Fixes #18 
Fixes #15 
Fixes https://github.com/healthyregions/chi-air/issues/18

## Approach
* feat: define `mean_pm25` and `nowcast_aqi` in a new file `operations.yml`
    * this offers a declarative approach to (hopefully) reusing some of the same pieces in a modular fashion
    * each operation requires their own cleaning script, even if that script only computes daily/weekly/etc averages
    * NOTE: Unfortunately, part of this is that we may lose the piecemeal aspects of this - we used to be able to run only the `--fetch` or only the `--clean` to use cached data. This is a nice feature that could hopefully be brought back, but unfortunately we're in a rush on this right now 
* TODO: ⚠️ definitely needs cleanup/refactoring, but this gets us there for now
* [x] TODO: 🛑 needs documentation/README update before merging
* [x] TODO: 🛑 needs workflows update before merging
* feat: generate a `{metric_name}.index.json` when updating each dataset - these indices may be different between metrics, so we track for each state
* feat: optimize dataset sort order (place hour first, so that we can immediately fetch the latest hourly map data)

## How to Test
1. Checkout and run this branch locally
2. Run the pipeline with your desired operations using the new all-in-one command: `docker compose run -it --build --rm aq --recent --op mean_pm25 nowcast_aqi`
    * Note the `--op` flag takes multiple arguments, so it should probably come after `startTime` if we're typing out the args (otherwise the arg parser might get confused)
    * You should see that `mean_pm25` is fetched and passed into the appropriate cleaning script
    * Once `mean_pm25` is completely updated, you should see that it proceeds and does the same for `nowcast_aqi`
3. Check console output & MinIO to verify final dataset contents


### Beware of Ratelimits
Beware of ratelimits if testing this with any variant of `--historical`. A single API key is limited to ~30 of these reports per day. This gives us a maximum of 5 or 6 parameters that we can support before our worst case scenario (New Year's Day on a Monday) is impossible to support.


Tested with `--historical --weekly`, output below:
```python
DEBUG:config:Writing parquet file to S3: chicago-aq/current/nowcast_aqi.parquet.brotli
INFO:config:Successfully updated parquet file in S3: chicago-aq/current/nowcast_aqi.parquet.brotli
INFO:config:Successfully updated nowcast_aqi dataset!
    type                 date  DACZY2913  DAETQ5676  DAEXF8484  DAHAJ0678  ...  DZIEF7974  DZIHS7092  DZKWB0839  DZLAV7766  DZTFU6199  DZUWB2477
0   week             2026-W11  35.550725  35.630694  39.373447  37.741201  ...  32.860766  34.889493  36.054607  47.332557  35.204193  40.823758
7    day           2026-03-15  38.958333      37.75  41.083333      39.25  ...  36.291667  36.208333  38.416667     50.375  37.416667     39.625
6    day           2026-03-14  25.541667  26.666667  27.916667  27.708333  ...       23.5  25.458333  25.416667     38.625       23.5     28.375
5    day           2026-03-13  31.916667  31.833333  31.041667      29.25  ...  27.833333  27.791667       31.5      42.25  28.708333  36.458333
4    day           2026-03-12  36.666667     34.875  35.166667       34.5  ...      28.25     32.375     35.625  45.333333     30.375      41.25
..   ...                  ...        ...        ...        ...        ...  ...        ...        ...        ...        ...        ...        ...
12  hour  2026-03-09 05:00:00       33.0       31.0       30.0       28.0  ...       26.0       27.0       31.0       42.0       28.0       29.0
11  hour  2026-03-09 04:00:00       33.0       31.0       30.0       29.0  ...       27.0       27.0       32.0       42.0       29.0       29.0
10  hour  2026-03-09 03:00:00       34.0       33.0       32.0       31.0  ...       28.0       27.0       32.0       42.0       33.0       29.0
9   hour  2026-03-09 02:00:00       32.0       29.0       33.0       31.0  ...       30.0       27.0       31.0       43.0       38.0       30.0
8   hour  2026-03-09 01:00:00       30.0       32.0       38.0       36.0  ...       34.0       27.0       29.0       37.0       46.0       28.0
```

```python
DEBUG:config:Writing parquet file to S3: chicago-aq/current/mean_pm25.parquet.brotli
INFO:config:Successfully updated parquet file in S3: chicago-aq/current/mean_pm25.parquet.brotli
INFO:config:Successfully updated mean_pm25 dataset!
    type                 date  DACZY2913  DAETQ5676  DAEXF8484  DAHAJ0678  ...  DZIEF7974  DZIHS7092  DZKWB0839  DZLAV7766  DZTFU6199  DZUWB2477
0   week             2026-W11   8.329528  11.276990  10.314636  10.089360  ...  10.152593  11.106493  12.317669  10.288714  11.882171  14.845142
7    day           2026-03-15   9.634722  10.125625   7.946979   7.978958  ...   9.601111   9.730972  10.952847   8.594792  11.386806  10.945937
6    day           2026-03-14   2.239965   5.754688   3.634757   3.725382  ...   4.098333   5.378160   4.589236   3.801771   4.103507   6.565799
5    day           2026-03-13   3.504896   5.298507   3.261979   2.714931  ...   4.079410   3.895069   5.399236   3.814062   4.341944   7.282569
4    day           2026-03-12   7.845795  10.674965   7.294861   6.980417  ...   7.799783   9.544514  11.649097   7.860521   8.782014  13.684931
..   ...                  ...        ...        ...        ...        ...  ...        ...        ...        ...        ...        ...        ...
12  hour  2026-03-09 04:00:00   4.970000   4.652500   3.797500   3.190000  ...   3.920000   4.385000   5.767500   5.873333   4.703333   4.936667
11  hour  2026-03-09 03:00:00   4.356667   4.423333   3.463333   2.752500  ...   3.990000   3.870000   6.346667   4.837500   4.385000   4.885000
10  hour  2026-03-09 02:00:00   5.105000   7.635000   3.010000   2.550000  ...   3.526667   4.472500   6.045000   4.306667   4.616667   4.166667
9   hour  2026-03-09 01:00:00   4.897500   3.426667   2.746667   1.797500  ...   3.017500   3.526667   5.590000   6.597500   5.010000   5.540000
8   hour           2026-03-09   2.976667   4.365000   2.172500   2.500000  ...   2.230000   3.462500   3.722500   2.666667   6.356667   3.396667

    ...    ...    ...    ...    ...    ...    ...    ...    ...    ...    ...    ...    ...    ...
```
