### PR TITLE
fix: season names missing first char

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -245,8 +245,8 @@ def merge_temporal_averages_to_df(metric_name, op_defn):
     seasonal = pd.read_csv(f'data/{metric_name}-summary-seasonal.csv').rename(columns=renameColumns)
     seasonal['type'] = 'season'
 
-    # Ensure date in the correct format - 2025-S03, 2025-S02, etc
-    seasonal['date'] = seasonal['date'].map(lambda d: d.split('-')[0] + '-' + d.split('-')[1][1:].zfill(2))
+    # Ensure date in the correct format - 2025-winter, 2025-spring, etc
+    #seasonal['date'] = seasonal['date'].map(lambda d: d.split('-')[0] + '-' + d.split('-')[1][1:].zfill(2))
 
     # Ensure column consistency: n_valid, type, date, is_valid, mean_pm2
     log.info(f'Compiling yearly sensor data...')


### PR DESCRIPTION
## Problem
When testing seasonal calculations, first character is missing:
```python
        type                 date  DACZY2913  DAETQ5676  DAEXF8484  ...  DZIHS7092  DZKWB0839  DZLAV7766  DZTFU6199  DZUWB2477
0     season           2026-inter  20.515009  26.959470  23.164020  ...  25.517428  28.738472  23.454293  24.958570  29.765116
```

## Approach
* fix: remove date mangling when `type=season`, R script outputs the correct value already

```python
        type                 date  DACZY2913  DAETQ5676  DAEXF8484  ...  DZIHS7092  DZKWB0839  DZLAV7766  DZTFU6199  DZUWB2477
1     season          2026-winter  20.515009  26.959470  23.164020  ...  25.517428  28.738472  23.454293  24.958570  29.765116
```