### PR TITLE
feat: added operations for Clarity PM2.5 + NO2

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -52,5 +52,5 @@ jobs:
 
       # Fetch Clarity API data and save raw files locally
       - name: Fetch Clarity sensor data, clean CSV data, merge into Parquet dataset
-        run: docker compose run --remove-orphans -e CLARITY_API_KEY=${{ secrets.CLARITY_API_TOKEN }} -e S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }} -e S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }} aq --historical --daily --op nowcast_aqi mean_pm25
+        run: docker compose run --remove-orphans -e CLARITY_API_KEY=${{ secrets.CLARITY_API_TOKEN }} -e S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }} -e S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }} aq --historical --daily --op nowcast_aqi clarity_pm25 clarity_no2
 

--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -52,4 +52,5 @@ jobs:
 
       # Fetch Clarity API data and save raw files locally
       - name: Fetch Clarity sensor data, clean CSV data, merge into Parquet dataset
-        run: docker compose run --remove-orphans -e CLARITY_API_KEY=${{ secrets.CLARITY_API_TOKEN }} -e S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }} -e S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }} aq --historical --monthly --op nowcast_aqi mean_pm25
+        run: docker compose run --remove-orphans -e CLARITY_API_KEY=${{ secrets.CLARITY_API_TOKEN }} -e S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }} -e S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }} aq --historical --monthly --op nowcast_aqi clarity_pm25 clarity_no2
+ 

--- a/.github/workflows/recent.yml
+++ b/.github/workflows/recent.yml
@@ -57,5 +57,5 @@ jobs:
 
       # Fetch Clarity API data and save raw files locally
       - name: Fetch Clarity sensor data, clean CSV data, merge into Parquet dataset
-        run: docker compose run --remove-orphans -e CLARITY_API_KEY=${{ secrets.CLARITY_API_TOKEN }} -e S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }} -e S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }} aq --recent --op nowcast_aqi mean_pm25
+        run: docker compose run --remove-orphans -e CLARITY_API_KEY=${{ secrets.CLARITY_API_TOKEN }} -e S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }} -e S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }} aq --recent --op nowcast_aqi clarity_pm25 clarity_no2
 

--- a/.github/workflows/seasonal.yml
+++ b/.github/workflows/seasonal.yml
@@ -61,4 +61,5 @@ jobs:
 
       # Fetch Clarity API data and save raw files locally
       - name: Fetch Clarity sensor data, clean CSV data, merge into Parquet dataset
-        run: docker compose run --remove-orphans -e CLARITY_API_KEY=${{ secrets.CLARITY_API_TOKEN }} -e S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }} -e S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }} aq --historical --seasonal --op nowcast_aqi mean_pm25
+        run: docker compose run --remove-orphans -e CLARITY_API_KEY=${{ secrets.CLARITY_API_TOKEN }} -e S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }} -e S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }} aq --historical --seasonal --op nowcast_aqi clarity_pm25 clarity_no2
+ 

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -52,4 +52,5 @@ jobs:
 
       # Fetch Clarity API data and save raw files locally
       - name: Fetch Clarity sensor data, clean CSV data, merge into Parquet dataset
-        run: docker compose run --remove-orphans -e CLARITY_API_KEY=${{ secrets.CLARITY_API_TOKEN }} -e S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }} -e S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }} aq --historical --weekly --op nowcast_aqi mean_pm25
+        run: docker compose run --remove-orphans -e CLARITY_API_KEY=${{ secrets.CLARITY_API_TOKEN }} -e S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }} -e S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }} aq --historical --weekly --op nowcast_aqi clarity_pm25 clarity_no2
+

--- a/.github/workflows/yearly.yml
+++ b/.github/workflows/yearly.yml
@@ -52,4 +52,5 @@ jobs:
 
       # Fetch Clarity API data and save raw files locally
       - name: Fetch Clarity sensor data, clean CSV data, merge into Parquet dataset
-        run: docker compose run --remove-orphans -e CLARITY_API_KEY=${{ secrets.CLARITY_API_TOKEN }} -e S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }} -e S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }} aq --historical --yearly --op nowcast_aqi mean_pm25
+        run: docker compose run --remove-orphans -e CLARITY_API_KEY=${{ secrets.CLARITY_API_TOKEN }} -e S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }} -e S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }} aq --historical --yearly --op nowcast_aqi clarity_pm25 clarity_no2
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,6 @@ services:
       - ./src:/home/rstudio/src/
       - ./scripts:/home/rstudio/scripts/
     command: >
-      python ./src/main.py --recent --fetch --clean --merge
+      python ./src/main.py --recent --op nowcast_aqi clarity_pm25 clarity_no2
 
 

--- a/operations.yml
+++ b/operations.yml
@@ -42,6 +42,8 @@ clarity_pm25:
   colName: 'pm2_5ConcMass1HourMean.value'
   postprocessing:
     renameColumns:
+      outputFrequency: 'type'
+      endOfPeriod: 'date'
       #"pm2_5ConcMassNowcast.value": 'clarity_pm25'
       #"pm2_5ConcMassNowcast": 'clarity_pm25'
       #"pm2_5ConcMass1HourMean.value": 'clarity_pm25'
@@ -55,17 +57,19 @@ clarity_no2:
   colName: 'no2Conc1HourMean.value'
   postprocessing:
     renameColumns:
-      #"no2Conc1HourMean.value": 'clarity_pm25'
-      #"no2Conc1HourMean": 'clarity_pm25'
-      #"no2Conc1HourMeanUsEpaAqi.value": 'clarity_pm25'
-      #"no2Conc1HourMeanUsEpaAqi": 'clarity_pm25'
+      outputFrequency: 'type'
+      endOfPeriod: 'date'
+      #"no2Conc1HourMean.value": 'clarity_no2'
+      #"no2Conc1HourMean": 'clarity_no2'
+      #"no2Conc1HourMeanUsEpaAqi.value": 'clarity_no2'
+      #"no2Conc1HourMeanUsEpaAqi": 'clarity_no2'
 
 
 nowcast_aqi:
   outputFrequency: hour
   metricSelect: 'only *nowcast*'
-  cleaningScript: ./scripts/aqi_qa_qc.R
-
+  cleaningScript: ./scripts/clarity_qa_qc.R
+  colName: 'pm2_5ConcMassNowcastUsEpaAqi.value'
   postprocessing:
     renameColumns:
       outputFrequency: 'type'

--- a/operations.yml
+++ b/operations.yml
@@ -9,7 +9,8 @@ mean_pm25:
   cleaningScript: ./scripts/pm25_qa_qc.R
   postprocessing:
     renameColumns:
-      #"pm2_5ConcMassIndividual.raw": 'mean_pm25'
+      #"pm2_5ConcMassIndividual.value": 'mean_pm25'
+      #"pm2_5ConcMassIndividual": 'mean_pm25'
       time: 'date'
       n_obs: 'n_valid'
       is_valid: 'is_valid'
@@ -32,6 +33,33 @@ mean_pm25:
       is_valid_year: 'is_valid'
       year: 'date'
       yearly_mean_pm25: 'mean_pm25'
+
+
+clarity_pm25:
+  outputFrequency: hour
+  metricSelect: 'only :pm25'
+  cleaningScript: ./scripts/clarity_qa_qc.R
+  colName: 'pm2_5ConcMass1HourMean.value'
+  postprocessing:
+    renameColumns:
+      #"pm2_5ConcMassNowcast.value": 'clarity_pm25'
+      #"pm2_5ConcMassNowcast": 'clarity_pm25'
+      #"pm2_5ConcMass1HourMean.value": 'clarity_pm25'
+      #"pm2_5ConcMass1HourMean": 'clarity_pm25'
+
+
+clarity_no2:
+  outputFrequency: hour
+  metricSelect: 'only :no2'
+  cleaningScript: ./scripts/clarity_qa_qc.R
+  colName: 'no2Conc1HourMean.value'
+  postprocessing:
+    renameColumns:
+      #"no2Conc1HourMean.value": 'clarity_pm25'
+      #"no2Conc1HourMean": 'clarity_pm25'
+      #"no2Conc1HourMeanUsEpaAqi.value": 'clarity_pm25'
+      #"no2Conc1HourMeanUsEpaAqi": 'clarity_pm25'
+
 
 nowcast_aqi:
   outputFrequency: hour

--- a/scripts/clarity_qa_qc.R
+++ b/scripts/clarity_qa_qc.R
@@ -1,0 +1,239 @@
+library(dplyr)
+library(lubridate)
+library(tidyr)
+library(purrr)
+library(slider)
+library(arrow)
+
+# Read configuration from environment variables
+
+log_level <- Sys.getenv("LOGLEVEL", unset = "info")
+raw_minute_output_dir <- Sys.getenv("CLEANED_OUTPUT_DIR", unset = "./data/")
+
+# Read OUTPUT_FORMAT envvar - possible values are json, csv (default), parquet
+output_format <- tolower(Sys.getenv("OUTPUT_FORMAT", unset = "csv"))
+
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) < 3) {
+    cat("ERROR: Missing required argument.\n", sep = "")
+    cat("   Please specify input CSV as first script argument\n", sep = "")
+    quit(status=-1)
+}
+
+metric_name <- args[1]
+input_path <- args[2]
+min_obs_per_hour <- as.integer(args[3])
+col_name <- args[4]
+
+# Compute hourly stats for ALL hours
+# Date Format:  2026-01-01 00:00:00, 2026-01-01 01:00:00, etc
+cat("Reading from input file: ",  input_path,"\n", sep = "")
+hourly <- readr::read_csv(input_path) %>%
+  mutate(date = floor_date(endOfPeriod, unit = "hour")) %>%
+  group_by(datasourceId, sourceId, date) %>%
+  summarise(
+    n_valid = sum(!is.na(.data[[col_name]])),
+    type = "hour",
+    metric = mean(.data[[col_name]], na.rm = TRUE),
+    .groups = "drop"
+  ) %>%
+  mutate(is_valid = n_valid >= min_obs_per_hour)
+
+# Keep only valid hour rows
+# Keep hours with n_obs ≥ 3 (completeness ≥ 75%)
+cat("Hourly rows (all): ", nrow(hourly), "\n")
+df_hourly <- hourly %>%
+  filter(is_valid) %>%
+  select(datasourceId, sourceId, date, metric, n_valid, is_valid) %>%
+  mutate(type = "hour") %>%
+  rename_at("metric", ~ metric_name)
+cat("Valid hourly rows (>=75% completeness): ", nrow(df_hourly), "\n")
+print(df_hourly)
+
+# Daily data
+# Daily aggregation data using only valid hours
+daily <- df_hourly %>%
+  # Date Format:  2026-01-01, 2026-01-02, etc
+  group_by(datasourceId, sourceId, date) %>%
+  mutate(date = floor_date(date, unit = "day")) %>%
+  summarise(
+    n_valid = n(),                     # Count of valid hours
+    type = "day",
+    metric = mean(get(metric_name), na.rm = TRUE),  # Mean of valid hourly means
+    .groups = "drop"
+  ) %>%
+  rename_at("metric", ~ metric_name) %>%
+  mutate(is_valid = n_valid > 20) # >20 hours
+
+# Keep only valid days
+cat("Daily rows (all): ", nrow(daily), "\n")
+df_daily <- daily %>% mutate(type = "day") %>% filter(is_valid)
+cat("Valid daily rows (>20 valid hours): ", nrow(df_daily), "\n")
+if (nrow(df_daily) > 0) {
+    print(df_daily)
+}
+
+
+# TODO: get real average code from UIC
+# stuff below is pretty much just made up
+
+
+# Weekly aggregation data using only valid days
+weekly <- df_daily %>%
+  # Date Format: 2026-W01, 2026-W02, etc
+  mutate(date = paste(lubridate::isoyear(date), sprintf("%02d", lubridate::isoweek(date)),sep = "-W")) %>%
+  group_by(datasourceId, sourceId, date) %>%
+  summarise(
+    n_valid = n(),                     # Count of valid days
+    type = "week",
+    metric = mean(get(metric_name), na.rm = TRUE),  # Mean of valid daily means
+    .groups = "drop"
+  ) %>%
+  rename_at("metric", ~ metric_name) %>%
+  mutate(is_valid = n_valid > 5) # >5 days
+
+# Keep only valid weeks
+cat("Weekly rows (all): ", nrow(weekly), "\n")
+df_weekly <- weekly %>% mutate(type = "week") %>% filter(is_valid)
+cat("Valid weekly rows (>5 valid days):" , nrow(df_weekly), "\n")
+if (nrow(df_weekly) > 0) {
+    print(df_weekly)
+}
+
+
+# Monthly aggregation data using only valid days
+# Date Format:  2026-01, 2026-02, etc
+monthly <- df_daily %>%
+  mutate(date = paste(lubridate::year(date), lubridate::month(date), sep = "-")) %>%
+  group_by(datasourceId, sourceId, date) %>%
+  summarise(
+    n_valid = n(),                     # Count of valid days
+    type = "month",
+    metric = mean(get(metric_name), na.rm = TRUE),  # Mean of valid daily means
+    .groups = "drop"
+  ) %>%
+  rename_at("metric", ~ metric_name) %>%
+  mutate(is_valid = n_valid > 21) # >21 days
+
+# Keep only valid months
+cat("Monthly rows (all): ", nrow(monthly), "\n")
+df_monthly <- monthly %>% mutate(type = "month") %>% filter(is_valid)
+cat("Valid monthly rows (>21 valid days): ", nrow(df_monthly), "\n")
+if (nrow(df_monthly) > 0) {
+    print(df_monthly)
+}
+
+# Seasonal aggregation data using only valid days
+# Date Format:  2026-summer, 2026-spring, etc
+seasonal <- df_daily %>%
+  mutate(date = case_match(month(floor_date(date, "month")),
+     1 ~ paste(lubridate::year(date), "winter", sep = "-"),
+     2 ~ paste(lubridate::year(date), "winter", sep = "-"),
+     3 ~ paste(lubridate::year(date), "spring", sep = "-"),
+     4 ~ paste(lubridate::year(date), "spring", sep = "-"),
+     5 ~ paste(lubridate::year(date), "spring", sep = "-"),
+     6 ~ paste(lubridate::year(date), "summer", sep = "-"),
+     7 ~ paste(lubridate::year(date), "summer", sep = "-"),
+     8 ~ paste(lubridate::year(date), "summer", sep = "-"),
+     9 ~ paste(lubridate::year(date), "autumn", sep = "-"),
+     10 ~ paste(lubridate::year(date), "autumn", sep = "-"),
+     11 ~ paste(lubridate::year(date), "autumn", sep = "-"),
+     12 ~ paste(lubridate::year(date)+1, "winter", sep = "-"))
+  ) %>% group_by(datasourceId, sourceId, date) %>%
+  summarise(
+    n_valid = n(),                     # Count of valid days
+    type = "season",
+    metric = mean(get(metric_name), na.rm = TRUE),  # Mean of valid daily means
+    .groups = "drop"
+  ) %>%
+  rename_at("metric", ~ metric_name) %>%
+  mutate(is_valid = n_valid > 60) # >60 days
+
+# Keep only valid seasons
+cat("Seasonal rows (all): ", nrow(seasonal), "\n")
+df_seasonal <- seasonal %>% mutate(type = "season") %>% filter(is_valid)
+cat("Valid seasonal rows (>60 valid days): ", nrow(df_seasonal), "\n")
+if (nrow(df_seasonal) > 0) {
+    print(df_seasonal)
+}
+
+# Yearly aggregation data using only valid days
+# Date Format:  2026, 2025, etc
+yearly <- df_daily %>%
+  mutate(date = lubridate::year(floor_date(date))) %>%
+  group_by(datasourceId, sourceId, date) %>%
+  summarise(
+    n_valid = n(),                     # Count of valid days
+    type = "year",
+    metric = mean(get(metric_name), na.rm = TRUE),  # Mean of valid daily means
+    .groups = "drop"
+  ) %>%
+  rename_at("metric", ~ metric_name) %>%
+  mutate(is_valid = n_valid > 250) # >250 days
+
+# Keep only valid years
+cat("Yearly rows (all): ", nrow(yearly), "\n")
+df_yearly <- yearly %>% mutate(type = "year") %>% filter(is_valid)
+cat("Valid yearly rows (>220 valid days): ", nrow(df_yearly), "\n")
+if (nrow(df_yearly) > 0) {
+    print(df_yearly)
+}
+
+# Per-sensor completeness summary
+# For each sensor
+# hours_total: total number of hourly records (including invalid hours)
+# hours_valid: number of hours that meet the completeness criterion (i.e., n_obs >= min_obs_per_hour,so is_valid_hour == TRUE)
+# pct_valid: percentage of valid hours out of total hours
+sensor_hourly_comp <- hourly %>%
+  group_by(datasourceId, sourceId) %>%
+  summarise(
+    hours_total = n(),
+    hours_valid = sum(is_valid),
+    pct_valid   = 100 * hours_valid / pmax(hours_total, 1),
+    .groups = "drop"
+  )
+
+cat("Sensor completeness summary:", nrow(sensor_hourly_comp), "sensors\n")
+print(head(sensor_hourly_comp))
+
+# Build up file name based on dataframe name + output_format (default=csv)
+#summary_completeness_file <- paste(raw_minute_output_dir, "mean_pm25-summary-completeness.", output_format, sep = "")
+summery_hourly_file <- paste(raw_minute_output_dir, metric_name, "-summary-hourly.", output_format, sep = "")
+summary_daily_file <- paste(raw_minute_output_dir, metric_name, "-summary-daily.", output_format, sep = "")
+summary_weekly_file <- paste(raw_minute_output_dir, metric_name, "-summary-weekly.", output_format, sep = "")
+summary_monthly_file <- paste(raw_minute_output_dir, metric_name, "-summary-monthly.", output_format, sep = "")
+summary_seasonal_file <- paste(raw_minute_output_dir, metric_name, "-summary-seasonal.", output_format, sep = "")
+summary_yearly_file <- paste(raw_minute_output_dir, metric_name, "-summary-yearly.", output_format, sep = "")
+
+# Write the chosen format to disk
+cat("Writing as OUTPUT_FORMAT=", output_format, " format...\n", sep = "")
+if (output_format == "parquet") {
+    #write_parquet(x = sensor_hourly_comp, sink = summary_completeness_file)
+    write_parquet(x = df_hourly, sink = summery_hourly_file)
+    write_parquet(x = df_daily, sink = summary_daily_file)
+    write_parquet(x = df_weekly, sink = summary_weekly_file)
+    write_parquet(x = df_monthly, sink = summary_monthly_file)
+    write_parquet(x = df_seasonal, sink = summary_seasonal_file)
+    write_parquet(x = df_yearly, sink = summary_yearly_file)
+} else if (output_format == "csv") {
+    #write.csv(sensor_hourly_comp, summary_completeness_file, row.names = FALSE)
+    write.csv(df_hourly, summery_hourly_file, row.names = FALSE)
+    write.csv(df_daily, summary_daily_file, row.names = FALSE)
+    write.csv(df_weekly, summary_weekly_file, row.names = FALSE)
+    write.csv(df_monthly, summary_monthly_file, row.names = FALSE)
+    write.csv(df_seasonal, summary_seasonal_file, row.names = FALSE)
+    write.csv(df_yearly, summary_yearly_file, row.names = FALSE)
+} else if (output_format == "json") {
+    #jsonlite::write_json(sensor_hourly_comp, summary_completeness_file, pretty = FALSE)
+    jsonlite::write_json(df_hourly, summery_hourly_file, pretty = FALSE)
+    jsonlite::write_json(df_daily, summary_daily_file, pretty = FALSE)
+    jsonlite::write_json(df_weekly, summary_weekly_file, pretty = FALSE)
+    jsonlite::write_json(df_monthly, summary_monthly_file, pretty = FALSE)
+    jsonlite::write_json(df_seasonal, summary_seasonal_file, pretty = FALSE)
+    jsonlite::write_json(df_yearly, summary_yearly_file, pretty = FALSE)
+} else {
+    cat("Skipping writing unknown file format: \"", output_format, "\"\n", sep = "")
+}
+
+
+cat("Data cleanup finished successfully!\n")

--- a/src/main.py
+++ b/src/main.py
@@ -92,7 +92,7 @@ def main(args):
             final_data_path = os.path.join(LOCAL_OUTPUT_DIR, metric_name + '-measurements.csv')
 
 
-            #measurements_df =  None
+            measurements_df = None
 
             # Fetch recent measurements from the clarity API
             # Write raw metrics (uncleaned) into the output folder

--- a/src/main.py
+++ b/src/main.py
@@ -68,7 +68,7 @@ def main(args):
 
     if args.ops:
         ops_defn_path = './operations.yml'
-        all_operations = ['mean_pm25', 'nowcast_aqi']
+        all_operations = [ 'nowcast_aqi', 'clarity_pm25', 'clarity_no2' ]
         ops_to_run = all_operations if args.ops == '*' else args.ops
         with open(ops_defn_path) as f:
             operations = yaml.safe_load(f)
@@ -136,13 +136,14 @@ def main(args):
                 log.info(f'    End time  : {end_time}')
 
                 # Fetch/poll for historical measurements and save locations from them
-                clarity = HistoricalMeasurements(s3api=s3api)
-                report_processed = clarity.historical_fetch_metrics(start_time=start_time, end_time=end_time, metricSelect=metricSelect, outputFrequency=outputFrequency, qc=qc)
-                historical_report_df, locations = clarity.download_report_contents(report_processed=report_processed)
-                historical_report_df.to_csv(fetched_data_path)
-                log.info(f'Historical data fetched successfully: {start_time} - {end_time} -> {fetched_data_path}')
-                #measurements_df = historical_report_df
-                #measurements_df = pd.read_csv(fetched_data_path) # None
+                if args.fetch:
+                    clarity = HistoricalMeasurements(s3api=s3api)
+                    report_processed = clarity.historical_fetch_metrics(start_time=start_time, end_time=end_time, metricSelect=metricSelect, outputFrequency=outputFrequency, qc=qc)
+                    historical_report_df, locations = clarity.download_report_contents(report_processed=report_processed)
+                    historical_report_df.to_csv(fetched_data_path)
+                    log.info(f'Historical data fetched successfully: {start_time} - {end_time} -> {fetched_data_path}')
+                    #measurements_df = historical_report_df
+                    #measurements_df = pd.read_csv(fetched_data_path) # None
 
             # Clean fetched measurements with R script (if provided)
             # Write raw metrics (uncleaned) into the output folder
@@ -152,6 +153,7 @@ def main(args):
                 inputFile=fetched_data_path,
                 metricName=metric_name,
                 minObsPerHour=op_defn['minObsPerHour'] if 'minObsPerHour' in op_defn else '1',
+                colName=op_defn['colName'] if 'colName' in op_defn else None,
             )
 
             measurements_df = merge_temporal_averages_to_df(metric_name=metric_name, op_defn=op_defn)
@@ -171,7 +173,8 @@ def main(args):
                 log.info(f'Running postprocessing for: {metric_name}...')
                 if 'renameColumns' in op_defn['postprocessing']:
                     renameColumns = op_defn['postprocessing']['renameColumns']
-                    measurements_df.rename(columns=renameColumns, inplace=True)
+                    if renameColumns is not None and len(renameColumns) > 0:
+                        measurements_df.rename(columns=renameColumns, inplace=True)
 
             log.info(f'Post-processing complete: {final_data_path}')
             #log.info(f'Computing temporal averages...')

--- a/src/utils.py
+++ b/src/utils.py
@@ -7,7 +7,7 @@ from decimal import Decimal
 
 # timedelta for microseconds/days/hours, relativedelta for months/years
 from datetime import datetime, UTC, timedelta
-from typing import Any
+from typing import Any, Optional
 
 from dateutil.relativedelta import relativedelta
 
@@ -180,14 +180,15 @@ def get_current_year_dates():
 def truncate(full_str: str|list[any], limit = 20):
     return f'{full_str[:limit]}...' if len(full_str) > limit else full_str
 
-def run_r_script(scriptPath: str, inputFile: str, metricName: str, minObsPerHour: int):
+def run_r_script(scriptPath: str, inputFile: str, metricName: str, minObsPerHour: int, colName: Optional[str]):
     try:
         output = subprocess.check_output([
             'Rscript',
             scriptPath,
             metricName,
             inputFile,
-            minObsPerHour
+            minObsPerHour,
+            colName
         ], universal_newlines=True, stderr=subprocess.PIPE)
         print(output.strip())
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -181,7 +181,7 @@ def truncate(full_str: str|list[any], limit = 20):
     return f'{full_str[:limit]}...' if len(full_str) > limit else full_str
 
 def run_r_script(scriptPath: str, inputFile: str, metricName: str, minObsPerHour: int, colName: Optional[str]):
-    try:
+    #try:
         output = subprocess.check_output([
             'Rscript',
             scriptPath,
@@ -192,18 +192,18 @@ def run_r_script(scriptPath: str, inputFile: str, metricName: str, minObsPerHour
         ], universal_newlines=True, stderr=subprocess.PIPE)
         print(output.strip())
 
-    except subprocess.CalledProcessError as ex:
-        log.error('R script failed. Error:', ex.stderr)
-        traceback.print_exc()
-        sys.exit(500)
-    except FileNotFoundError as ex:
-        log.error('ERROR: File not found.', ex)
-        traceback.print_exc()
-        sys.exit(404)
-    except Exception as ex:
-        log.error('ERROR: Rscript encountered an unknown exception: ', ex)
-        traceback.print_exc()
-        sys.exit(501)
+    # except subprocess.CalledProcessError as ex:
+    #     log.error('R script failed. Error:', ex.stderr)
+    #     traceback.print_exc()
+    #     sys.exit(500)
+    # except FileNotFoundError as ex:
+    #     log.error(f'ERROR: File not found - {str(ex)}')
+    #     traceback.print_exc()
+    #     sys.exit(404)
+    # except Exception as ex:
+    #     log.error(f'ERROR: Rscript encountered an unknown exception: {str(ex)}')
+    #     traceback.print_exc()
+    #     sys.exit(501)
 
 
 def merge_temporal_averages_to_df(metric_name, op_defn):


### PR DESCRIPTION
## Problem
The finalized PM2.5 cleaning process won't be completed for awhile. In the meantime, we would like to switch to using Clarity's pre-cleaned metrics for PM2.5.

We would also like an easy way to include other generic pre-cleaned Clarity metrics, such as NO2, in the future

Fixes #32 
Fixes #33

## Approach
* feat: added an operation for `clarity_pm25` - currently uses `pm2_5ConcMass1HourMean.value`
* feat: added an operation for `clarity_no2` - currently uses `no2Conc1HourMean.value`

For a full list of column options, see https://api-guide.clarity.io/v2/measurements/metrics-dictionary.html#hour-aggregations

## How to Test
TL;DR
You should be able to run these new operations using similar commands to our previous metrics:
```
docker compose run -it --build --rm aq --recent --op nowcast_aqi clarity_no2 clarity_pm25
```

NOTE: we're starting to get into the territory of "expensive usage" for `---historical`, so it can no longer be tested as thoroughly or frequently - we're very close to hitting our possible maximum of 4 metrics. If we want to support more than 4 metrics in the long-term, then we'll need to re-evaluate this architecture

### Clarity PM2.5
Fetch and calculate `--recent` metrics for `clarity_pm25` - this would replace our existing mean_pm25 with a fresh copy, meaning we lose our history (but we could maybe backfill?)
```bash
docker compose run -it --build --rm aq --recent --op clarity_pm25
```

You should see that at the end, an updated/merged dataset is produced:
```Python
INFO:config:Successfully updated clarity_pm25 dataset!
   type                 date  DACZY2913  DAETQ5676  DAEXF8484  DAHAJ0678  ...  DZIEF7974  DZIHS7092  DZKWB0839  DZLAV7766  DZTFU6199  DZUWB2477
5  hour  2026-05-07 20:00:00      10.47       7.00       6.79       5.91  ...       6.04       6.33       7.68       8.05       6.00      10.16
4  hour  2026-05-07 19:00:00      11.72       8.95       8.14       7.35  ...       7.43       7.84       8.67       9.89       7.80      10.02
3  hour  2026-05-07 18:00:00      10.22       8.59       7.90       7.40  ...       7.14       8.06       9.46       9.40       7.44       9.43
2  hour  2026-05-06 22:00:00       7.95       9.25       7.21       7.61  ...       7.05       7.17       8.33       9.45       6.83      11.39
1  hour  2026-05-06 21:00:00       7.46       7.06       8.24       7.12  ...       7.69       6.73       9.55       8.33       6.94       9.02
0  hour  2026-05-06 20:00:00       8.32       8.61       8.09       7.82  ...       6.93       7.71       7.74       9.43       7.13       9.89
```

### Clarity NO2
Fetch and calculate `--recent` metrics for `clarity_no2`
```bash
docker compose run -it --build --rm aq --recent --op clarity_no2
```

You should see that at the end, an updated/merged dataset is produced:
```Python
INFO:config:Successfully updated clarity_no2 dataset!
   type                 date  DACZY2913  DAETQ5676  DAEXF8484  DAHAJ0678  ...  DZIEF7974  DZIHS7092  DZKWB0839  DZLAV7766  DZTFU6199  DZUWB2477
3  hour  2026-05-07 20:00:00      18.47      13.46      13.33      13.12  ...      16.36      14.88      22.33      16.16      13.94      16.72
2  hour  2026-05-07 19:00:00      25.85      13.04      11.03      11.70  ...      14.29      13.58      23.48      15.56      11.39      17.17
1  hour  2026-05-07 18:00:00      19.36      12.68       9.69      12.30  ...      12.71      12.48      27.39      12.44      10.16      16.72
0  hour  2026-05-07 17:00:00      13.80      12.73       9.88      13.12  ...      15.81      11.89      19.02      11.97      11.33      15.04
```
