### PR TITLE
feat: remove "invalid" rows from fetched dataset when qc=true

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,9 +7,11 @@ dependencies:
   - s3fs=2025.3.0
 
   # TODO - pin all versions
-  - requests
+  - requests=2.34.2
   - pandas=2.3.3
-  - pyarrow
-  - python-dateutil
-  - duckdb
-  - PyYAML
+  - geopandas=1.1.3
+  - shapely=2.1.2
+  - pyarrow=24.0.0
+  - python-dateutil=2.9.0.post0
+  - duckdb=1.5.3
+  - PyYAML=6.0.3

--- a/operations.yml
+++ b/operations.yml
@@ -1,12 +1,41 @@
 
 # Key here determines output_dataset_name: {metric}.parquet.brotli
 
+# {metric_name}:
+#
+#   outputFrequency: 'hour'   # data temporal resolution, one of 'day', 'hour', or 'minute'
+#
+#   metricSelect: 'only :no2' # limits metrics returned. if not present, all metrics will be returned.
+#                             # see https://api-guide.clarity.io/v2/measurements/metrics-select.html
+#
+#   minObsPerHour: 1          # number of "valid" observations per hour for the hour to itself be considered "valid"
+#
+#   qc: true                  # if true, fetch qcFlags + qcAssessment for further review/cleaning
+#                             # this is needed for us to discard invalid datapoints
+#
+#   cleaningScript: path/to/script.R
+#                             # the R cleaning script that should be run for this data.
+#                             # for hourly cloud-computed metrics, we can use clarity_qa_qc.R
+#
+#   colName: 'no2Conc1HourMean.value'
+#                             # if using clarity_qa_qc.R or if qc=true, you must provide the name of the column that contains the desired metrics.
+#
+#   postprocessing:           # define any postprocessing steps for this data
+#                             # sometimes this is just a precaution, and sometimes this is necessary
+#
+#     renameColumns:          # renames "current_column_name" to "desired_column_name"
+#       current_column_name: desired_column_name
+#
+
+
+# TODO: currently unused - pending additional data cleanup support from UIC
 mean_pm25:
   outputFrequency: minute
   metricSelect: 'only :pm25 + :internal'
   minObsPerHour: '3'
-  qc: true
   cleaningScript: ./scripts/pm25_qa_qc.R
+  colName: 'pm2_5ConcMassIndividual.value'
+  qc: true
   postprocessing:
     renameColumns:
       #"pm2_5ConcMassIndividual.value": 'mean_pm25'
@@ -40,6 +69,7 @@ clarity_pm25:
   metricSelect: 'only :pm25'
   cleaningScript: ./scripts/clarity_qa_qc.R
   colName: 'pm2_5ConcMass1HourMean.value'
+  qc: true
   postprocessing:
     renameColumns:
       outputFrequency: 'type'
@@ -55,6 +85,7 @@ clarity_no2:
   metricSelect: 'only :no2'
   cleaningScript: ./scripts/clarity_qa_qc.R
   colName: 'no2Conc1HourMean.value'
+  qc: true
   postprocessing:
     renameColumns:
       outputFrequency: 'type'
@@ -70,6 +101,7 @@ nowcast_aqi:
   metricSelect: 'only *nowcast*'
   cleaningScript: ./scripts/clarity_qa_qc.R
   colName: 'pm2_5ConcMassNowcastUsEpaAqi.value'
+  qc: true
   postprocessing:
     renameColumns:
       outputFrequency: 'type'
@@ -78,4 +110,4 @@ nowcast_aqi:
       #'pm2_5ConcMassNowcastUsEpaAqi': 'nowcast_aqi'
 
 
-# Future: ... define new operations for NO2 + Black Carbon ...
+# Future: ... define new operations for Black Carbon ...

--- a/src/clarity.py
+++ b/src/clarity.py
@@ -72,6 +72,47 @@ class ClarityAPI(object):
             log.fatal('Encountered a failure while logging response error. Shutting down....')
             sys.exit(99)
 
+    def assign_groups(self, df: pd.DataFrame):
+        log.info('Assigning groups...')
+        import geopandas as gpd
+        import pandas as pd
+        from shapely.geometry import Point
+
+        # Step 1: Convert the pandas DataFrame into a GeoDataFrame
+        # GeoJSON uses longitude first (X), then latitude (Y)
+        geometry = [Point(xy) for xy in zip(df["locationLongitude"], df["locationLatitude"])]
+        gdf_locations = gpd.GeoDataFrame(df, geometry=geometry, crs="EPSG:4326")
+
+        # Step 2: Load the boundary GeoJSON files
+        # Use same boundaries as the frontend, we can fetch these directly from github
+        path_prefix = 'https://raw.githubusercontent.com/healthyregions/chi-air/refs/heads/main/public/geojson/'
+        gdf_wards = gpd.read_file(f"{path_prefix}/boundaries_wards_2023_.geojson")
+        gdf_communities = gpd.read_file(f"{path_prefix}/community_areas.geojson")
+        gdf_zips = gpd.read_file(f"{path_prefix}/chiZipCodes.geojson")
+
+        # Step 3: Map your specific GeoJSON property names to target column names
+        # Ensure these match the exact keys inside your files' "properties" objects
+        gdf_wards = gdf_wards[["ward", "geometry"]]  # e.g., property is "ward"
+        gdf_communities = gdf_communities[["community", "geometry"]]  # e.g., property is "community"
+        gdf_zips = gdf_zips[["zip", "geometry"]]  # e.g., property is "zip"
+
+        # Step 4: Perform sequential spatial joins (Point-in-Polygon)
+        # "left" ensures you keep all locations even if they fall outside a boundary
+        final_gdf = gpd.sjoin(gdf_locations, gdf_wards, how="left", predicate="within")
+        final_gdf = final_gdf.drop(columns=["index_right"])  # Drop index artifact from first join
+
+        final_gdf = gpd.sjoin(final_gdf, gdf_communities, how="left", predicate="within")
+        final_gdf = final_gdf.drop(columns=["index_right"])
+
+        final_gdf = gpd.sjoin(final_gdf, gdf_zips, how="left", predicate="within")
+        final_gdf = final_gdf.drop(columns=["index_right"])
+
+        # Step 5: Clean up and save back to Parquet
+        # Drop the spatial geometry column to revert to a standard Pandas DataFrame
+        return pd.DataFrame(final_gdf).drop(columns=["geometry"])
+        #final_df = pd.DataFrame(final_gdf).drop(columns=["geometry"])
+        #final_df.to_parquet("locations_with_boundaries.parquet")
+
 
     def gather_locations(self, measurements_df):
         log.info('Gathering locations...')
@@ -92,10 +133,16 @@ class ClarityAPI(object):
         # Zip up locations + datasources using datasourceID as key, flatten + include org annotations (name/group/tags)
         subset_columns = ['datasourceId', 'currentSubscriptionId', 'currentSourceId', 'name', 'group', 'tags']
         locations_df = pd.merge(locations_df, datasources_df[subset_columns], on='datasourceId', how='left')
-        log.info('Merged locations + datasources! Writing result to S3...')
+
+        log.info('Merged locations + datasources!')
+        log.info('Assigning groups: community, zip, ward')
+        locations_df = self.assign_groups(locations_df)
+
+        log.info('Spatial groups have been assigned!')
+        log.info('Writing resulting locations dataset to S3...')
 
         sorted_df = locations_df.set_index(['datasourceId', 'sourceId']).sort_values(axis='rows', by=['datasourceId', 'sourceId']).reset_index()
-        return sorted_df[['datasourceId', 'sourceId', 'currentSourceId', 'sourceType', 'locationLatitude', 'locationLongitude', 'name', 'group', 'tags']]
+        return sorted_df[['datasourceId', 'sourceId', 'currentSourceId', 'sourceType', 'locationLatitude', 'locationLongitude', 'name', 'group', 'tags', 'community', 'ward', 'zip']]
 
 
     # Parse csv-wide Response and return CSV contents as a pandas Dataframe

--- a/src/main.py
+++ b/src/main.py
@@ -94,9 +94,10 @@ def main(args):
 
             measurements_df = None
 
-            # Fetch recent measurements from the clarity API
-            # Write raw metrics (uncleaned) into the output folder
+            # Fetch recent or historical measurements from the clarity API
+            # Write cloud-computed metrics (uncleaned) into the output folder
             if not args.historical:
+                # Recent Measurements
                 start_of_3_hours, _ = get_current_3_hours_dates()
                 start_time = args.startTime if args.startTime else start_of_3_hours
                 log.info(f'Fetching recent measurement data from: {CLARITY_HOSTNAME}')
@@ -110,9 +111,8 @@ def main(args):
                 #measurements_df = recent_measurements_df
                 #measurements_df = pd.read_csv(fetched_data_path) # None
 
-            # Fetch recent or historical measurements from the clarity API
-            # Write raw metrics (uncleaned) into the output folder
             else:
+                # Historical Measurements
                 start_time = args.startTime if args.startTime else HISTORICAL_START_TIME
                 end_time = args.endTime if args.endTime else HISTORICAL_END_TIME
 
@@ -145,8 +145,19 @@ def main(args):
                     #measurements_df = historical_report_df
                     #measurements_df = pd.read_csv(fetched_data_path) # None
 
+            # TODO: determine how unquoted boolean values are parsed / interpreted
+            if 'qc' in op_defn and (op_defn['qc'] == True or op_defn['qc'] == "true"):
+                # Read cloud-computed metrics (uncleaned) from the output folder
+                uncleaned_df = pd.read_csv(fetched_data_path)
+                col_name = op_defn['colName'].replace('.value', '.qcAssessment')
+
+                # Cleaning step: Remove any rows where qcAssessment is 'invalid'
+                cleaned_df = uncleaned_df[uncleaned_df[f"{col_name}"] != "invalid"]
+
+                # Write cleaned metrics back to the output folder (overwrite cloud-computed metrics)
+                cleaned_df.to_csv(fetched_data_path)
+
             # Clean fetched measurements with R script (if provided)
-            # Write raw metrics (uncleaned) into the output folder
             log.info(f'Cleaning up measurement data with R script: {op_defn["cleaningScript"]}...')
             run_r_script(
                 scriptPath=op_defn['cleaningScript'],

--- a/src/main.py
+++ b/src/main.py
@@ -147,12 +147,16 @@ def main(args):
 
             # TODO: determine how unquoted boolean values are parsed / interpreted
             if 'qc' in op_defn and (op_defn['qc'] == True or op_defn['qc'] == "true"):
+                log.info(f'Purging rows with invalid qc: {op_defn["qc"]}')
+
                 # Read cloud-computed metrics (uncleaned) from the output folder
                 uncleaned_df = pd.read_csv(fetched_data_path)
                 col_name = op_defn['colName'].replace('.value', '.qcAssessment')
+                log.info(f'  Number of rows before purging={len(uncleaned_df)}')
 
                 # Cleaning step: Remove any rows where qcAssessment is 'invalid'
                 cleaned_df = uncleaned_df[uncleaned_df[f"{col_name}"] != "invalid"]
+                log.info(f'  Number of rows after purging={len(cleaned_df)}')
 
                 # Write cleaned metrics back to the output folder (overwrite cloud-computed metrics)
                 cleaned_df.to_csv(fetched_data_path)


### PR DESCRIPTION
## Problem
Our map differs from Clarity because they secretly discard "invalid" rows - I was lead to believe that their "cloud-computed metrics" would do this by default but it seems that this is a manual step that we must perform ourselves 🙃 

Partially fixes #31 
Fixes #35 

## Approach
* feat: when `qc=true`, use `{colName}.qcAssessment` column to remove "invalid" rows (partially fixes #31)
* feat: automatically generate spatial joins when gathering locations (fixes #35)
    * uses our same boundary files from the frontend chi-air repository

## How to Test
1. Fetch any metrics (recent or historical) via docker compose: ``
    * You should see the following output
```python
DEBUG:config:Releasing lockfile...
DEBUG:config:Released lockfile!
INFO:config:Data fetched successfully: /home/rstudio/data/nowcast_aqi-raw-measurements.csv
INFO:config:Purging rows with invalid qc: True            <------ You should see this line if qc=true
INFO:config:  Number of rows before purging=867           <------ If any `invalid` rows are purged, then
INFO:config:  Number of rows after purging=858            <------ these two numbers will be different
INFO:config:Cleaning up measurement data with R script: ./scripts/clarity_qa_qc.R...
Reading from input file: /home/rstudio/data/nowcast_aqi-raw-measurements.csv
Hourly rows (all):  858 
```
2. Above that section, you should see the locations dataset is printed
    * You should see that the locations dataset now contains a column each for `community`, `zip`, and `ward`:
```
INFO:config:Successfully updated parquet file in S3: chicago-aq/current/locations.parquet.brotli
INFO:config:Successfully updated locations dataset!
    datasourceId  sourceId        community currentSourceId group  locationLatitude  locationLongitude               name    sourceType     tags ward    zip
0      DACZY2913  A3KT6T74      ROGERS PARK        A3KT6T74  None           42.0025           -87.6722      Rogers Park 2  CLARITY_NODE       []   49  60626
1      DAETQ5676  A74GKPFK        MONTCLARE        A74GKPFK  None           41.9235           -87.7992        Montclare 2  CLARITY_NODE       []   36  60707
2      DAEXF8484  AP7HCCXJ  MOUNT GREENWOOD        AP7HCCXJ  None           41.7059           -87.7104  Mount Greenwood 1  CLARITY_NODE       []   19  60655
3      DAHAJ0678  A9QKCK4N          ASHBURN        A9QKCK4N  None           41.7529           -87.7392          Ashburn 1  CLARITY_NODE       []   18  60652
4      DAHWZ2321  AQ96FCW7      ALBANY PARK        AQ96FCW7  None           41.9621           -87.7082      Albany Park 2  CLARITY_NODE       []   33  60625
..           ...       ...              ...             ...   ...               ...                ...                ...           ...      ...  ...    ...
284    DZIHS7092  A44F7W3K   ARCHER HEIGHTS        A44F7W3K  None           41.8152           -87.7195   Archer Heights 2  CLARITY_NODE       []   14  60632
285    DZKWB0839  ANNVFLYT        EAST SIDE        ANNVFLYT  None           41.7134           -87.5357        East Side 2  CLARITY_NODE  [ComEd]   10  60617
286    DZLAV7766  AQ3669WV           AUSTIN        AQ3669WV  None           41.8786           -87.7549           Austin 4  CLARITY_NODE       []   28  60644
287    DZTFU6199  A6LYVKHK          ASHBURN        A6LYVKHK  None           41.7396           -87.7214          Ashburn 7  CLARITY_NODE       []   18  60652
288    DZUWB2477  ANMRQ7C4   NORTH LAWNDALE        ANMRQ7C4  None           41.8682           -87.7357   North Lawndale 1  CLARITY_NODE  [ComEd]   24  60624

[289 rows x 12 columns]
```
^^ After clearing it out, this is the fresh locations dataset that was created from the past ~3 hours of metrics